### PR TITLE
SitePathLink - rapprochements avec OSM et CNIG accessibilité

### DIFF
--- a/NeTEx/accessibilité/index.md
+++ b/NeTEx/accessibilité/index.md
@@ -2212,6 +2212,37 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <p>Correspond à l'attribut TRONCON_CHEMINEMENT.statutVoie dans le standard CNIG</p>
 </td>
 </tr>
+<tr>
+<td><em>TactileGuidingStripContrast</em></td>
+<td><p>indique si la couleur de l'éventuelle bande de guidage constraste suffisamment avec la couleur du sol :</p>
+<ul>
+<li><p><em>true</em></p></li>
+<li><p><em>false</em></li>
+</ul>
+<p>À rapprocher du tag OpenStreetMap <a target="_blank" href="https://wiki.openstreetmap.org/wiki/FR:Key:tactile_paving">tactile_paving</a>.</p>
+</td>
+</tr>
+<tr>
+<td><em>TactileGuidingStripStatus</em></td>
+<td><p>Fournit des détails supplémentaires sur l'éventuelle bande de guidage :</p>
+<ul>
+<li><p><em>primitive : lorsqu'il n'y a pas de bande de guidage à proprement parler mais qu'un élément de décor ou un rebord peut être utilisé à cet effet</em></p></li>
+<li><p><em>incorrect : lorsqu'il existe une bande de guidage mais qu'elle ne correspond pas à un cheminement réellement empruntable (passe au milieu d'un obstacle sans le coutourner par exemple)</em></p></li>
+<li><p><em>bad : lorsque la bande de guidage est dégradée et difficile à interpréter</em></p></li>
+</ul>
+<p>À rapprocher du tag OpenStreetMap <a target="_blank" href="https://wiki.openstreetmap.org/wiki/FR:Key:tactile_paving">tactile_paving</a>.</p>
+</td>
+</tr>
+<tr>
+<td><em>TactileWarningStripContrast</em></td>
+<td><p>indique si la couleur des bandes d'éveil à la vigilance aux extrémités constraste suffisamment avec la couleur du sol :</p>
+<ul>
+<li><p><em>true</em></p></li>
+<li><p><em>false</em></li>
+</ul>
+<p>À rapprocher du tag OpenStreetMap <a target="_blank" href="https://wiki.openstreetmap.org/wiki/FR:Key:tactile_paving">tactile_paving</a>.</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/NeTEx/accessibilité/index.md
+++ b/NeTEx/accessibilité/index.md
@@ -1993,15 +1993,15 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 </tr>
 <tr class="odd">
 <td></td>
-<td><em>Width</em></td>
-<td>PassengersPerMinute</td>
+<td><em>MinimumWidth</em></td>
+<td>LengthType</td>
 <td>0:1</td>
 <td>Largeur du cheminement</td>
 </tr>
 <tr class="even">
 <td></td>
-<td><em>Flooring</em></td>
-<td><em>xsd :decimal</em></td>
+<td><em>FlooringType</em></td>
+<td><em>FlooringTypeEnum</em></td>
 <td>0:1</td>
 <td><p>Type de surface au sol</p>
 <ul>
@@ -2019,7 +2019,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <li><p><em>Wood (bois)</em></p></li>
 <li><p><em>Stone (pierre)</em></p></li>
 <li><p><em>Grass (gazon)</em></p></li>
-<li><p><em>Dirt (terre)</em></p></li>
+<li><p><em>Earth (terre)</em></p></li>
 <li><p><em>Gravel (graviers)</em></p></li>
 <li><p><em>Uneven (inégal)</em></p></li>
 <li><p><em>Unknown (inconnu)</em></p></li>
@@ -2029,7 +2029,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <tr class="odd">
 <td></td>
 <td><em>RightSideBorder</em></td>
-<td><em>FlooringTypeEnum</em></td>
+<td><em>BorderTypeEnum</em></td>
 <td>0:1</td>
 <td><p>Type de bordure sur le côté droit (dans le sens direct, from/to, du cheminement)</p>
 <ul>
@@ -2062,14 +2062,14 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <tr class="odd">
 <td></td>
 <td><em>TiltAngle</em></td>
-<td><em>BorderTypeEnum</em></td>
+<td><em>xsd:integer</em></td>
 <td>0:1</td>
 <td>Dévers (inclinaison latérale) de +20 a -20 degrès (dans le sens direct, from/to, du cheminement)</td>
 </tr>
 <tr class="even">
 <td></td>
-<td><em>CodedTilt</em></td>
-<td><em>xsd:integer</em></td>
+<td><em>TiltType</em></td>
+<td><em>TiltTypeEnum</em></td>
 <td>0:1</td>
 <td><p>Valeur codée du dévers</p>
 <ul>

--- a/NeTEx/accessibilité/index.md
+++ b/NeTEx/accessibilité/index.md
@@ -5064,3 +5064,6 @@ http://cnig.gouv.fr/IMG/documents_wordpress/2022/05/220504_Standard_CNIG_Accessi
 Documentation collaborative sur la cartographie des cheminements piétons
 et de l'accessibilité dans OpenStreetMap : 
 https://wiki.openstreetmap.org/wiki/FR:Cheminements_pi%C3%A9tons
+
+Règles de conversion vers le profil, pour OpenStreetMap et le standard CNIG Accessibilité :
+https://doc.transport.data.gouv.fr/documentation/normes-europeennes/accessibilite

--- a/NeTEx/accessibilité/index.md
+++ b/NeTEx/accessibilité/index.md
@@ -1790,7 +1790,7 @@ recommandé de ne pas trop les subdiviser (et donc de ne pas les faire
 trop petits) pour éviter de surcharger l'utilisateur en information et
 aussi pour limiter le volume d'information à gérer par les systèmes.
 
-<div class="table-title">PathLink – Element</div>
+<div class="table-title">SitePathLink – Élément</div>
 
 <table style="width:100%;">
 <colgroup>
@@ -1803,9 +1803,9 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <tbody>
 <tr class="odd">
 <td><strong>Classifi­cation</strong></td>
-<td><strong>Name</strong></td>
+<td><strong>Nom</strong></td>
 <td><strong>Type</strong></td>
-<td><strong>Cardinality</strong></td>
+<td><strong>Cardinalité</strong></td>
 <td><strong>Description</strong></td>
 </tr>
 <tr class="even">
@@ -1813,9 +1813,9 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td><em>::></em></td>
 <td><em>Link</em></td>
 <td><em>::></em></td>
-<td><p>PATH LINK inherite de LINK.</p>
-<p><span class="hl">L'attribut Distance, hérité de LINK, est rendu obligatoire pour les tonçon de cheminement par le profil pour l'accessibilité.</span></p>
-<p><span class="hl">Notez aussi que, en complément de l'attribut Transition, si une information de pente précise est souhaitée, on utilisera les informations de hauter/altitude associées aux points aux extrémités du LINK.</span></p>
+<td><p>PATH LINK hérite de LINK.</p>
+<p><span class="hl">L'attribut Distance, hérité de LINK, est rendu obligatoire pour les tronçons de cheminement par le profil pour l'accessibilité.</span></p>
+<p><span class="hl">Notez aussi que, en complément de l'attribut Transition, si une information de pente précise est souhaitée, on utilisera les informations de hauteur/altitude associées aux points aux extrémités du LINK.</span></p>
 <p><span class="hl">De plus, toujours dans le contexte du profil pour l'accessibilité, la géométrie des </span><span class="hl">PATH LINKs sera systématiquement décrite avec l'attribut </span><em><strong><span class="hl">LineString</span></strong></em><span class="hl"> (GML) aussi </span><span class="hl">hérité de LINK. Il est important de bien noter que cette géométrie peut être différente, notament au niveau des extrémités, des centroïdes des objets référencés par </span><em><strong><span class="hl">From</span></strong></em><span class="hl"> et </span><em><strong><span class="hl">To</span></strong></em><span class="hl"> (qui sont généralement des centroïdes de zone, relativement imprécis). De plus les extrémités du LineString devront coincider avec ceux des autre </span><span class="hl">PATH LINK connectés dans le cadre d'un NAVIGATION PATH.</span></p></td>
 </tr>
 <tr class="odd">
@@ -1823,22 +1823,22 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td>id</td>
 <td>PathLinkIdType</td>
 <td>1:1</td>
-<td>Identifiand du PATH LINK.</td>
+<td>Identifiant du PATH LINK.</td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
 <td>From</td>
 <td>PathLinkEnd</td>
 <td>1:1</td>
-<td>Point ou lieu de départ du PATH LINK.</td>
+<td>Point ou lieu de départ du PATH LINK. Voir tableau suivant</td>
 </tr>
 <tr class="odd">
 <td>«FK»</td>
 <td>To</td>
 <td>PathLinkEnd</td>
 <td>1:1</td>
-<td><p>Point ou lieu de fin du PATH LINK.</p>
-<p><em><strong><span class="hl">From</span></strong></em><span class="hl"> et </span><em><strong><span class="hl">To</span></strong></em><span class="hl"> peuvent référencer le même espace, mais avec des </span><em><strong><span class="hl">LineString </span></strong><span class="hl">(voir ci-dessus)</span></em><span class="hl"> différentes. On utlisera notament cette particularité pour traverser des équipements long (comme un tapi roulant) situé dans un EQUIPMENT PLACE (ZONE).</span></p></td>
+<td><p>Point ou lieu de fin du PATH LINK. Voir tableau suivant</p>
+<p><em><strong><span class="hl">From</span></strong></em><span class="hl"> et </span><em><strong><span class="hl">To</span></strong></em><span class="hl"> peuvent référencer le même espace, mais avec des </span><em><strong><span class="hl">LineString </span></strong><span class="hl">(voir ci-dessus)</span></em><span class="hl"> différentes. On utilisera notament cette particularité pour traverser des équipements long (comme un tapis roulant) situés dans un EQUIPMENT PLACE (ZONE).</span></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1868,7 +1868,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td>Covered</td>
 <td>CoveredEnum</td>
 <td>0:1</td>
-<td>Typde e couvertrure</td>
+<td>Type de couvertrure</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1910,14 +1910,14 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td>Towards</td>
 <td>MultilingualString</td>
 <td>0:1</td>
-<td>Direction indiquée qand le cheminement est effectué dans le sens FROM vers TO.</td>
+<td>Direction indiquée quand le cheminement est effectué dans le sens FROM vers TO (sens direct).</td>
 </tr>
 <tr class="odd">
 <td></td>
 <td>Back</td>
 <td>MultilingualString</td>
 <td>0:1</td>
-<td>Direction indiquée qand le cheminement est effectué dans le sens TO vers FROM.</td>
+<td>Direction indiquée quand le cheminement est effectué dans le sens TO vers FROM.</td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1931,7 +1931,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td>AllowedUse</td>
 <td>DirectionOfUseEnum</td>
 <td>0:1</td>
-<td>Allowed direction of use of PATH LINK.</td>
+<td>Indique si le cheminement est empruntable dans les deux sens.</td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1944,7 +1944,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <li><p><em>down (descente)</em></p></li>
 <li><p><em>level (pas de changement de niveau)</em></p></li>
 <li><p><em>upAndDown (montée puis descente)</em></p></li>
-<li><p><em>downAndUp (descente puis montés)</em></p></li>
+<li><p><em>downAndUp (descente puis montée)</em></p></li>
 </ul></td>
 </tr>
 <tr class="odd">
@@ -1984,7 +1984,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td><p>Précision du type de caractèristique associée au PATH LINK:</p>
 <p>:</p>
 <ul>
-<li><p><em>pathway (sntier)</em></p></li>
+<li><p><em>pathway (sentier)</em></p></li>
 <li><p><em>corridor (couloir)</em></p></li>
 <li><p><em>overpass (passerelle, pont)</em></p></li>
 <li><p><em>underpass (passage sous-terrain)</em></p></li>
@@ -1993,14 +1993,14 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 </tr>
 <tr class="odd">
 <td></td>
-<td><em><strong>Width</strong></em></td>
+<td><em>Width</em></td>
 <td>PassengersPerMinute</td>
 <td>0:1</td>
 <td>Largeur du cheminement</td>
 </tr>
 <tr class="even">
 <td></td>
-<td><em><strong>Flooring</strong></em></td>
+<td><em>Flooring</em></td>
 <td><em>xsd :decimal</em></td>
 <td>0:1</td>
 <td><p>Type de surface au sol</p>
@@ -2023,15 +2023,15 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <li><p><em>Gravel (graviers)</em></p></li>
 <li><p><em>Uneven (inégal)</em></p></li>
 <li><p><em>Unknown (inconnu)</em></p></li>
+<li><p><em>Other (autre)</em></p></li>
 </ul>
-<p><em>Other</em></p></td>
 </tr>
 <tr class="odd">
 <td></td>
-<td><em><strong>RightSideBorder</strong></em></td>
+<td><em>RightSideBorder</em></td>
 <td><em>FlooringTypeEnum</em></td>
 <td>0:1</td>
-<td><p>Type de bordure sur le côté droit (dans le sens direct, fom/to, du cheminement)</p>
+<td><p>Type de bordure sur le côté droit (dans le sens direct, from/to, du cheminement)</p>
 <ul>
 <li><p><em>Wall (mur)</em></p></li>
 <li><p><em>Grass (gazon)</em></p></li>
@@ -2054,21 +2054,21 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 </tr>
 <tr class="even">
 <td></td>
-<td><em><strong>LeftDideBorder</strong></em></td>
+<td><em>LeftSideBorder</em></td>
 <td><em>BorderTypeEnum</em></td>
 <td>0:1</td>
-<td>Type de bordure sur le côté droit (dans le sens direct, fom/to, du cheminement)</td>
+<td>Type de bordure sur le côté droit (dans le sens direct, from/to, du cheminement)</td>
 </tr>
 <tr class="odd">
 <td></td>
-<td><em><strong>TiltAngle</strong></em></td>
+<td><em>TiltAngle</em></td>
 <td><em>BorderTypeEnum</em></td>
 <td>0:1</td>
-<td>Dévers (inclinaison latérale) de +20 a -20 degrès (dans le sens direct, fom/to, du cheminement)</td>
+<td>Dévers (inclinaison latérale) de +20 a -20 degrès (dans le sens direct, from/to, du cheminement)</td>
 </tr>
 <tr class="even">
 <td></td>
-<td><em><strong>CodedTilt</strong></em></td>
+<td><em>CodedTilt</em></td>
 <td><em>xsd:integer</em></td>
 <td>0:1</td>
 <td><p>Valeur codée du dévers</p>
@@ -2082,10 +2082,10 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 </tr>
 <tr class="odd">
 <td></td>
-<td><em><strong>TactileWarningStrip</strong></em></td>
+<td><em>TactileWarningStrip</em></td>
 <td><em>TactileWarningEnum</em></td>
 <td>0:1</td>
-<td><p>Indique s’il y a des bandes d’interception podotactyles (in the direction of the pathLink way) :</p>
+<td><p>Indique s’il y a des bandes d’interception podotactiles (dans le sens direct, from/to, du cheminement) :</p>
 <ul>
 <li><p><em>TactileStripAtBeginning (bande au depart)</em></p></li>
 <li><p><em>TactileStripAtEnd (bande à l’arrivèe)</em></p></li>
@@ -2096,10 +2096,10 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 </tr>
 <tr class="even">
 <td></td>
-<td><em><strong>TactileGuidingStrip</strong></em></td>
+<td><em>TactileGuidingStrip</em></td>
 <td>xsd:boolean</td>
 <td>0:1</td>
-<td>Indique s’il y a des bandes de guidage podotactyles.</td>
+<td>Indique s’il y a des bandes de guidage podotactiles.</td>
 </tr>
 
 <tr class="even">
@@ -2107,10 +2107,10 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td>TransferDuration</td>
 <td>TransferDuration</td>
 <td>0:1</td>
-<td><p>Temps moyens pour franchir le cheminement (4 valeures disponibles):</p>
+<td><p>Temps moyens pour franchir le cheminement (4 valeurs disponibles):</p>
 <ul>
 <li><p><em>DefaultDuration (durée moyenne)</em></p></li>
-<li><p><em>FrequentTravellerDuration (durée pour un voyageur habituée)</em></p></li>
+<li><p><em>FrequentTravellerDuration (durée pour un voyageur habitué)</em></p></li>
 <li><p><em>OccasionalTravellerDuration (durée pour un voyageur occasionel)</em></p></li>
 <li><p><em>MobilityRestrictedTravellerDuration (durée pour un voyageur à mobilité réduite)</em></p></li>
 </ul></td>

--- a/NeTEx/accessibilité/index.md
+++ b/NeTEx/accessibilité/index.md
@@ -197,6 +197,13 @@ Ce document a été élaboré sur la base des réflexions et échanges
 intervenus dans le cadre du GT7 ainsi qu'en utilisant les conclusions de
 l'étude CAMERA.
 
+Ce document a également été enrichi à l'aide du standard d’échange de
+données sur l’accessibilité des déplacements pour les personnes en
+situation de handicap produit par le groupe de travail CNIG sur
+l'Accessibilité. Ce modèle a pour but de décrire l'accessibilité
+des cheminements extérieurs en voirie, typiquement des trottoirs
+reliant un arrêt de transport en commun à l’entrée d’un ERP.
+
 Si la première motivation pour la définition de ce profil est bien
 l'accessibilité, cet objet n'est en aucun cas limitatif et les
 informations contenues (en particulier concernant les équipements et les
@@ -720,6 +727,22 @@ AO
 <div class="Definition">
 
 Autorité Organisatrice de Transports
+
+</div>
+
+CNIG
+
+<div class="Definition">
+
+Conseil National de l'Information Géographique
+
+</div>
+
+OSM
+
+<div class="Definition">
+
+OpenStreetMap
 
 </div>
 
@@ -1828,7 +1851,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td>KeyList</td>
 <td>0:1</td>
 <td><p>Ensemble de couples clef/valeur (voir le profil Éléments Commun pour plus de détail sur ce mécanisme d'extension).</p>
-<p><span class="hl">Dans le cadre du profil, on les utilisera pour décrire des identifiants secondaires de l'objet ou pour compléter les attributs.</span></p>
+<p><span class="hl">Dans le cadre du profil, on les utilisera pour décrire des identifiants secondaires de l'objet ou pour compléter les attributs. Voir tableau ci-dessous.</span></p>
 <p><span class="hl">Remarque : il est interdit, dans le profil, d’utiliser le système de clef/valeur pour décrire des informations qui pourraient être fournies avec des attributs NeTEx existants (même s’ils ne sont pas retenus par le profil).</span></p></td>
 </tr>
 <tr class="even">
@@ -1838,7 +1861,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td><p>0:1</p>
 <p><span class="hl">1:1</span></p></td>
 <td><p>Longueur du tronçon de cheminement.</p>
-<p><span class="hl">L'attribut Distance, hérité de LINK, est rendu obligatoire pour les tronçons de cheminement par le profil pour l'accessibilité.</span></p></td>
+<p><span class="hl">L'attribut Distance, hérité de LINK, est rendu obligatoire pour les tronçons de cheminement par le profil pour l'accessibilité. Il s'agit de la distance parcourue le long du tronçon de cheminement et non de la distance à vol d'oiseau entre les points de départ et d'arrivée.</span></p></td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
@@ -1878,7 +1901,6 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td>0:1</td>
 <td>ACCESSIBILITY du PATH LINK.</td>
 </tr>
-
 <tr class="odd">
 <td></td>
 <td>PublicUse</td>
@@ -1892,7 +1914,8 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td>Covered</td>
 <td>CoveredEnum</td>
 <td>0:1</td>
-<td>Type de couvertrure</td>
+<td>Type de couverture.
+<p><span class="hl">La valeur <em>mixed</em> n'est pas retenue dans le cadre du profil pour l'accessibilité : il convient dans ce cas de segmenter en plusieurs SitePathLink avec chacun un type de couverture propre.</span></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1921,7 +1944,6 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td>0:1</td>
 <td>Indique si le cheminement est pratiquable en fauteuil roulant.</td>
 </tr>
-
 <tr class="odd">
 <td>«cntd»</td>
 <td>facilities</td>
@@ -1948,7 +1970,8 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td>NumberOfSteps</td>
 <td>xsd:integer</td>
 <td>0:1</td>
-<td>Nombre de marche rencontrées sur le cheminement.</td>
+<td>Nombre de marches rencontrées sur le cheminement.
+<p><span class="hl">Il s'agit du nombre de marches total de l'escalier si le tronçon de cheminement correspond à un escalier, ou du nombre de ressauts ou marches isolées sinon.</span></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1967,9 +1990,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <li><p><em>up (montée)</em></p></li>
 <li><p><em>down (descente)</em></p></li>
 <li><p><em>level (pas de changement de niveau)</em></p></li>
-<li><p><em>upAndDown (montée puis descente)</em></p></li>
-<li><p><em>downAndUp (descente puis montée)</em></p></li>
-</ul></td>
+</ul><p><span class="hl">Les valeurs <em>upAndDown</em> (montée puis descente) et <em>downAndUp</em> (descente puis montée) ne sont pas retenues dans le cadre du profil pour l'accessibilité : il convient dans ces cas de segmenter en plusieurs SitePathLink avec chacun un type de transition propre.</span></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2020,7 +2041,8 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td><em>MinimumWidth</em></td>
 <td>LengthType</td>
 <td>0:1</td>
-<td>Largeur du cheminement</td>
+<td><p>Largeur du cheminement</p>
+<p><span class="hl">La largeur renseignée doit tenir compte des éventuels obstacles présents le long du tronçon de cheminement.</span></p>
 </tr>
 <tr class="even">
 <td></td>
@@ -2150,10 +2172,49 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td><em>placeEquipments</em></td>
 <td>Equipment</td>
 <td>0:1</td>
-<td>Liste des équipements dont dépend le tronçon de cheminement.</td>
+<td>Liste des AccessEquipment (équipements d’accès) dont dépend le tronçon de cheminement.</td>
 </tr>
 </tbody>
 </table>
+
+<div class="table-title">KeyList pour SitePathLink</div>
+
+<table style="width:100%;">
+<tbody>
+<tr class="odd">
+<td><strong>Clef</strong></td>
+<td><strong>Valeurs et description</strong></td>
+</tr>
+<tr>
+<td><em>FlooringStatus</em></td>
+<td><p>État du revêtement :</p>
+<ul>
+<li><p><em>none (pas de revêtement)</em></p></li>
+<li><p><em>good (bon état)</em></p></li>
+<li><p><em>worn (dégradation sans gravité)</em></p></li>
+<li><p><em>discomfortable (dégradation entraînant une difficulté d'usage ou d'inconfort)</em></p></li>
+<li><p><em>hazardous (dégradation entraînant un problème de sécurité immédiat)</em></p></li>
+</ul>
+<p>À rapprocher de l'attribut CIRCULATION.etatRevetement dans le standard CNIG</p>
+</td>
+</tr>
+<tr>
+<td><em>HighwayType</em></td>
+<td><p>Type de voie d’après le schéma directeur de la voirie français :</p>
+<ul>
+<li><p><em>street (voie classique : rue, avenue, boulevard)</em></p></li>
+<li><p><em>limitedSpeedStreet (zone 30)</em></p></li>
+<li><p><em>livingStreet (zone de rencontre)</em></p></li>
+<li><p><em>pedestrian (rue piétonne, aire piétonne, sente piétonne)</em></p></li>
+<li><p><em>bicycle (voie verte)</em></p></li>
+<li><p><em>unclassified (autre type de voie inscrit au schéma directeur de la voirie)</em></p></li>
+</ul>
+<p>Correspond à l'attribut TRONCON_CHEMINEMENT.statutVoie dans le standard CNIG</p>
+</td>
+</tr>
+</tbody>
+</table>
+
 
 <div class="table-title">PathLinkEnd – Element</div>
 
@@ -4958,3 +5019,7 @@ cette étude ne porte que sur les modes de surface)*
 
 EN 28701, Intelligent transport systems - Public transport -
 Identification of Fixed Objects in Public Transport (IFOPT)
+
+Standard CNIG Accessibilité du cheminement en voirie : 
+http://cnig.gouv.fr/IMG/documents_wordpress/2022/05/220504_Standard_CNIG_Accessibilite_v2022-05.pdf 
+(v2021-10 rev. 2022-05)

--- a/NeTEx/accessibilité/index.md
+++ b/NeTEx/accessibilité/index.md
@@ -204,6 +204,11 @@ l'Accessibilité. Ce modèle a pour but de décrire l'accessibilité
 des cheminements extérieurs en voirie, typiquement des trottoirs
 reliant un arrêt de transport en commun à l’entrée d’un ERP.
 
+Des compléments issus de l'ontologie du projet OpenStreetMap ont également
+été apportés au document. OpenStreetMap (OSM) est un projet collaboratif
+de cartographie proposant une base de données géographiques libre du monde
+entier.
+
 Si la première motivation pour la définition de ce profil est bien
 l'accessibilité, cet objet n'est en aucun cas limitatif et les
 informations contenues (en particulier concernant les équipements et les
@@ -2195,7 +2200,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <li><p><em>discomfortable (dégradation entraînant une difficulté d'usage ou d'inconfort)</em></p></li>
 <li><p><em>hazardous (dégradation entraînant un problème de sécurité immédiat)</em></p></li>
 </ul>
-<p>À rapprocher de l'attribut CIRCULATION.etatRevetement dans le standard CNIG</p>
+<p>À rapprocher de l'attribut CIRCULATION.etatRevetement dans le standard CNIG et du tag OpenStreetMap <a target="_blank" href="https://wiki.openstreetmap.org/wiki/FR:Key:smoothness">smoothness</a>.</p>
 </td>
 </tr>
 <tr>
@@ -5054,3 +5059,7 @@ Identification of Fixed Objects in Public Transport (IFOPT)
 Standard CNIG Accessibilité du cheminement en voirie : 
 http://cnig.gouv.fr/IMG/documents_wordpress/2022/05/220504_Standard_CNIG_Accessibilite_v2022-05.pdf 
 (v2021-10 rev. 2022-05)
+
+Documentation collaborative sur la cartographie des cheminements piétons
+et de l'accessibilité dans OpenStreetMap : 
+https://wiki.openstreetmap.org/wiki/FR:Cheminements_pi%C3%A9tons

--- a/NeTEx/accessibilité/index.md
+++ b/NeTEx/accessibilité/index.md
@@ -1813,10 +1813,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td><em>::></em></td>
 <td><em>Link</em></td>
 <td><em>::></em></td>
-<td><p>PATH LINK hérite de LINK.</p>
-<p><span class="hl">L'attribut Distance, hérité de LINK, est rendu obligatoire pour les tronçons de cheminement par le profil pour l'accessibilité.</span></p>
-<p><span class="hl">Notez aussi que, en complément de l'attribut Transition, si une information de pente précise est souhaitée, on utilisera les informations de hauteur/altitude associées aux points aux extrémités du LINK.</span></p>
-<p><span class="hl">De plus, toujours dans le contexte du profil pour l'accessibilité, la géométrie des </span><span class="hl">PATH LINKs sera systématiquement décrite avec l'attribut </span><em><strong><span class="hl">LineString</span></strong></em><span class="hl"> (GML) aussi </span><span class="hl">hérité de LINK. Il est important de bien noter que cette géométrie peut être différente, notament au niveau des extrémités, des centroïdes des objets référencés par </span><em><strong><span class="hl">From</span></strong></em><span class="hl"> et </span><em><strong><span class="hl">To</span></strong></em><span class="hl"> (qui sont généralement des centroïdes de zone, relativement imprécis). De plus les extrémités du LineString devront coincider avec ceux des autre </span><span class="hl">PATH LINK connectés dans le cadre d'un NAVIGATION PATH.</span></p></td>
+<td>PATH LINK hérite de LINK.</td>
 </tr>
 <tr class="odd">
 <td>«PK»</td>
@@ -1824,6 +1821,33 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td>PathLinkIdType</td>
 <td>1:1</td>
 <td>Identifiant du PATH LINK.</td>
+</tr>
+<tr class="even">
+<td></td>
+<td>KeyList</td>
+<td>KeyList</td>
+<td>0:1</td>
+<td><p>Ensemble de couples clef/valeur (voir le profil Éléments Commun pour plus de détail sur ce mécanisme d'extension).</p>
+<p><span class="hl">Dans le cadre du profil, on les utilisera pour décrire des identifiants secondaires de l'objet ou pour compléter les attributs.</span></p>
+<p><span class="hl">Remarque : il est interdit, dans le profil, d’utiliser le système de clef/valeur pour décrire des informations qui pourraient être fournies avec des attributs NeTEx existants (même s’ils ne sont pas retenus par le profil).</span></p></td>
+</tr>
+<tr class="even">
+<td></td>
+<td>Distance</td>
+<td>DistanceType</td>
+<td><p>0:1</p>
+<p><span class="hl">1:1</span></p></td>
+<td><p>Longueur du tronçon de cheminement.</p>
+<p><span class="hl">L'attribut Distance, hérité de LINK, est rendu obligatoire pour les tronçons de cheminement par le profil pour l'accessibilité.</span></p></td>
+</tr>
+<tr class="odd">
+<td>«cntd»</td>
+<td>LineString</td>
+<td>gmlLineString</td>
+<td><p>0:1</p>
+<p><span class="hl">1:1</span></p></td>
+<td><p>Géométrie du tronçon de cheminement.</p>
+<p><span class="hl">Dans le contexte du profil pour l'accessibilité, la géométrie des PATH LINKs sera systématiquement décrite avec l'attribut <em><strong>LineString</strong></em> (GML) hérité de LINK. Il est important de bien noter que cette géométrie peut être différente, notament au niveau des extrémités, des centroïdes des objets référencés par <em><strong>From</strong></em> et <em><strong>To</strong></em> (qui sont généralement des centroïdes de zone, relativement imprécis). De plus les extrémités du LineString devront coincider avec ceux des autres PATH LINK connectés dans le cadre d'un NAVIGATION PATH.</span></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -2064,7 +2088,7 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <td><em>TiltAngle</em></td>
 <td><em>xsd:integer</em></td>
 <td>0:1</td>
-<td>Dévers (inclinaison latérale) de +20 a -20 degrès (dans le sens direct, from/to, du cheminement)</td>
+<td>Dévers (inclinaison latérale) de +20 a -20 degrés (dans le sens direct, from/to, du cheminement)</td>
 </tr>
 <tr class="even">
 <td></td>
@@ -2082,6 +2106,13 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 </tr>
 <tr class="odd">
 <td></td>
+<td><em>Gradient</em></td>
+<td><em>xsd:integer</em></td>
+<td>0:1</td>
+<td>Pente en degrés (dans le sens direct, from/to, du cheminement)</td>
+</tr>
+<tr class="even">
+<td></td>
 <td><em>TactileWarningStrip</em></td>
 <td><em>TactileWarningEnum</em></td>
 <td>0:1</td>
@@ -2094,14 +2125,13 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <li><p><em>unknown (inconnu)</em></p></li>
 </ul></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td></td>
 <td><em>TactileGuidingStrip</em></td>
 <td>xsd:boolean</td>
 <td>0:1</td>
 <td>Indique s’il y a des bandes de guidage podotactiles.</td>
 </tr>
-
 <tr class="even">
 <td>«cntd»</td>
 <td>TransferDuration</td>
@@ -2114,6 +2144,13 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <li><p><em>OccasionalTravellerDuration (durée pour un voyageur occasionel)</em></p></li>
 <li><p><em>MobilityRestrictedTravellerDuration (durée pour un voyageur à mobilité réduite)</em></p></li>
 </ul></td>
+</tr>
+<tr class="odd">
+<td></td>
+<td><em>placeEquipments</em></td>
+<td>Equipment</td>
+<td>0:1</td>
+<td>Liste des équipements dont dépend le tronçon de cheminement.</td>
 </tr>
 </tbody>
 </table>

--- a/NeTEx/accessibilité/index.md
+++ b/NeTEx/accessibilité/index.md
@@ -204,9 +204,10 @@ l'Accessibilité. Ce modèle a pour but de décrire l'accessibilité
 des cheminements extérieurs en voirie, typiquement des trottoirs
 reliant un arrêt de transport en commun à l’entrée d’un ERP.
 
-Des compléments issus de l'ontologie du projet OpenStreetMap ont également
-été apportés au document. OpenStreetMap (OSM) est un projet collaboratif
-de cartographie proposant une base de données géographiques libre du monde
+Des compléments permettant d'assurer la mise en relation avec l'ontologie
+ du projet OpenStreetMap ont également été apportés au document.
+ OpenStreetMap (OSM) est un projet collaboratif de cartographie
+ proposant une base de données géographiques libre du monde
 entier.
 
 Si la première motivation pour la définition de ce profil est bien
@@ -1980,6 +1981,14 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 </tr>
 <tr class="odd">
 <td></td>
+<td>MinimumWidth</td>
+<td>LengthType</td>
+<td>0:1</td>
+<td><p>Largeur du cheminement</p>
+<p><span class="hl">La largeur renseignée doit tenir compte des éventuels obstacles présents le long du tronçon de cheminement.</span></p>
+</tr>
+<tr class="odd">
+<td></td>
 <td>AllowedUse</td>
 <td>DirectionOfUseEnum</td>
 <td>0:1</td>
@@ -2040,14 +2049,6 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <li><p><em>underpass (passage sous-terrain)</em></p></li>
 <li><p><em>tunnel (tunnel)</em></p></li>
 </ul></td>
-</tr>
-<tr class="odd">
-<td></td>
-<td><em>MinimumWidth</em></td>
-<td>LengthType</td>
-<td>0:1</td>
-<td><p>Largeur du cheminement</p>
-<p><span class="hl">La largeur renseignée doit tenir compte des éventuels obstacles présents le long du tronçon de cheminement.</span></p>
 </tr>
 <tr class="even">
 <td></td>
@@ -2112,6 +2113,13 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 </tr>
 <tr class="odd">
 <td></td>
+<td><em>Gradient</em></td>
+<td><em>xsd:integer</em></td>
+<td>0:1</td>
+<td>Pente en degrés (dans le sens direct, from/to, du cheminement)</td>
+</tr>
+<tr class="odd">
+<td></td>
 <td><em>TiltAngle</em></td>
 <td><em>xsd:integer</em></td>
 <td>0:1</td>
@@ -2130,13 +2138,6 @@ aussi pour limiter le volume d'information à gérer par les systèmes.
 <li><p><em>mediumRightTilt (dévers moyen à droite)</em></p></li>
 <li><p><em>strongRightTilt (dévers fort à droite)</em></p></li>
 </ul></td>
-</tr>
-<tr class="odd">
-<td></td>
-<td><em>Gradient</em></td>
-<td><em>xsd:integer</em></td>
-<td>0:1</td>
-<td>Pente en degrés (dans le sens direct, from/to, du cheminement)</td>
 </tr>
 <tr class="even">
 <td></td>


### PR DESCRIPTION
Voici le détail des modifications proposées ici :

Mise en conformité avec le XSD Netex :
* correction de types d'attributs erronés (par ex : TiltAngle de type BorderTypeEnum )
* attribut Width remplacé par MinimumWidth
* attribut Flooring remplacé par FlooringType
* attribut CodedTilt remplacé par TiltType
* valeur `dirt` de FlooringType remplacé par `earth`

Ajout des attributs suivants :
* Distance et LineString (hérités de LINK et rendus obligatoires dans le profil)
* Gradient
* placeEquipments
* KeyList

Remarques en jaune :
* retrait du profil les attributs mixtes (Transition : upAndDown / downAndUp et Covered : mixed) pour suggérer à la place de couper en plusieurs SitePathLink comme c'est le cas dans le standard CNIG
* précision sur NumberOfSteps : les ressauts sont à prendre en compte
* précision sur MinimumWidth : la largeur doit tenir compte des éventuels obstacles
* retrait de l'utilisation des altitudes sur les extrémités des SITEPATHLINKs au profit de l'attribut Gradient

Extensions (KeyList) proposées :
* État du revêtement : FlooringStatus
* Type de voie d’après le schéma directeur de la voirie : HighwayType
* Contraste de la bande de guidage : TactileGuidingStripContrast
* Caractérisation de la bande de guidage : TactileGuidingStripStatus
* Contraste des bandes d'éveil à la vigilance : TactileWarningStripContrast

Mention d'OpenStreetMap et du standard accessibilité CNIG en introduction, dans les abréviations et la bibliographie

Amélioration de la traduction, corrections diverses d'orthographe et de mise en forme