### PR TITLE
Corrige la référence vers la liste des modes dans le Profil Éléments Communs

### DIFF
--- a/NeTEx/arrets/index.md
+++ b/NeTEx/arrets/index.md
@@ -1313,7 +1313,7 @@ plates-formes composites à deux côtés ou plus ou à des sections nommées.
 <td><em><strong>TransportMode</strong></em></td>
 <td><em>VehicleModeEnum</em></td>
 <td>1:1</td>
-<td>Mode de transport principal pour le LIEU. La liste des modes est présentée en 5.15 dans le Profil Éléments Communs.</td>
+<td>Mode de transport principal pour le LIEU. La liste des modes est présentée en 6.17 dans le Profil Éléments Communs.</td>
 </tr>
 <tr class="odd">
 <td><em>(Choice)</em></td>


### PR DESCRIPTION
Dans le document NeTEx - Profil France - Description des arrêts, le paragraphe [7.2.5 Attributs du LIEU D’ARRÊT (StopPlace)](http://localhost:1313/normes/netex/arrets/#attributs-du-lieu-darr%C3%AAt-stopplace) fait une mauvaise référence concernant la liste des modes (présentée dans Profil Éléments Communs)

**Version corrigée**

![image](https://github.com/etalab/transport-normes/assets/24570/8f4590d1-5791-4af3-adc1-91b751fafcd7)
