### PR TITLE
Éditorialisation de l'ordre des sections du profil NeTEx France

### DIFF
--- a/NeTEx/accessibilite/index.md
+++ b/NeTEx/accessibilite/index.md
@@ -4,6 +4,7 @@ date: 2024-11-21T00:00:00+00:05
 draft: false
 tags: ["NeTEx"]
 autonumbering: true
+weight: 6
 aliases:
 - /normes/netex/accessibilité/
 ---

--- a/NeTEx/arrets/index.md
+++ b/NeTEx/arrets/index.md
@@ -4,6 +4,7 @@ date: 2024-11-21T00:00:00+00:01
 draft: false
 tags: ["NeTEx"]
 autonumbering: true
+weight: 2
 ---
 
 **Avant-propos**

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -4,6 +4,7 @@ date: 2024-11-21T00:00:00+00:00
 draft: false
 tags: ["NeTEx"]
 autonumbering: true
+weight: 1
 ---
 
 **Avant-propos**

--- a/NeTEx/horaires/index.md
+++ b/NeTEx/horaires/index.md
@@ -4,6 +4,7 @@ date: 2024-11-21T00:00:00+00:02
 draft: false
 tags: ["NeTEx"]
 autonumbering: true
+weight: 5
 ---
 
 **Avant-propos**

--- a/NeTEx/parkings/index.md
+++ b/NeTEx/parkings/index.md
@@ -4,6 +4,7 @@ date: 2024-11-21T00:00:00+00:02
 draft: false
 tags: ["NeTEx"]
 autonumbering: true
+weight: 3
 ---
 
 **Avant-propos**

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -4,6 +4,7 @@ date: 2024-11-21T00:00:00+00:04
 draft: false
 tags: ["NeTEx"]
 autonumbering: true
+weight: 4
 ---
 
 **Avant-propos**

--- a/NeTEx/tarifs/index.md
+++ b/NeTEx/tarifs/index.md
@@ -4,6 +4,7 @@ date: 2024-11-21T00:00:00+01:00
 draft: false
 tags: ["NeTEx"]
 autonumbering: true
+weight: 7
 ---
 
 **Avant-propos**


### PR DESCRIPTION
Voir:
- https://github.com/etalab/transport-normes-site/issues/31

Hugo, le CMS utilisé sur le site, permet de forcer l'ordre via un système de poids. Les poids les plus lourds se retrouvent davantage en bas de la page.

> Page weight controls the position of a page within a collection that is sorted by weight. Assign weights using non-zero integers. Lighter items float to the top, while heavier items sink to the bottom. Unweighted or zero-weighted elements are placed at the end of the collection.

https://gohugo.io/methods/page/weight/

J'ai fait un test sur une preview un peu bricolée (https://github.com/etalab/transport-normes-site/pull/34) et ça semble fonctionner.

SIRI, qui est sans `weight`, se retrouve en bas, ce qui nous va.