### PR TITLE
Tarifs - rendre explicite les propriétés du FareTable

### DIFF
--- a/NeTEx/tarifs/index.md
+++ b/NeTEx/tarifs/index.md
@@ -5543,40 +5543,34 @@ la GRILLE TARIFAIRE.</span>
 
 <div class='table-title'>FareTable – Element</div>
 
-| **Classification** | **Name**                              | **Type**           | **Cardinality** | **Description**                                                                               |
+| **Classification** | **Nom** (Source)                             | **Type**           | **Cardinalité** | **Description**                                                                               |
 |--------------------|---------------------------------------|--------------------|-----------------|-----------------------------------------------------------------------------------------------|
-| ::\>               | ::\>                                  | *PriceGroup*       | ::\>            | FARE TABLE hérite de PRICE GROUP***.***                                                       |
+| ::\>               | ::\>         | *DataManagedObject*       | ::\>            |      |
+| ::\>               | ::\>         | *EntityInVersion*       | ::\>            |      |
 | « PK »             | ***id***                              | *FareTableIdType*  | 1:1             | Identifiant du FARE TABLE.                                                                    |
-|                    | ***StartDate***                       | *xsd:date*         | 0:1             | Date de début de validité du prix.                                                            |
-|                    | ***EndDate***                         | *xsd:date*         | 0:1             | Date de fin de validité du prix.                                                              |
-| XGRP               | ***FareTableReferencesGroup***        | *xmlGroup*         | 0:\*            | Éléments de structure tarifaire pouvant recevoir un prix et donc associés à cette cellule.    |
-| XGRP               | ***FareTableCommonAssignmentsGroup*** | *xmlGroup*         | 0:1             | Association d'un élément de structure tarifaire pour une cellule.                             |
-| XGRP               | ***FareTableHeadingsGroup***          | *xmlGroup*         | 0:1             | En-têtes de lignes et de colonnes pour le tableau. Les CELL peuvent y faire référence.        |
-|                    | ***EmbargoUntil***                    | *xsd:dateTime*     | 0:1             | Les prix ne seront communiqués qu'à partir de cette date.                                     |
-| « cntd »           | ***cells***                           | *Cell*             | 0:\*            | Un tuple dans une TABLE DES TARIFS qui associe une ou plusieurs entités tarifaires à un prix. |
-| « cntd »           | ***noticeAssignments***               | *NoticeAssignment* | 0:\*            | NOTICEs s’appliquant à l’ensemble de la FARE TABLE                                            |
-
-<div class='table-title'>FareTableReferencesGroup – Group</div>
-
-| **Classification** | **Name**                 |                                        | **Type**                           | **Cardinality** | **Description**                                                                |
-|--------------------|--------------------------|----------------------------------------|------------------------------------|-----------------|--------------------------------------------------------------------------------|
-| « FK »             | ***TypeOfFareTableRef*** |                                        | *TypeOfFareTableRef*               | 0:1             | Classification de la FARE TABLE.                                               |
-| « cntd »           | ***pricesFor***          |                                        | *PriceableObjectRef+*              | 0:\*            | PRICEABLE OBJECT pouvant faire l'objet d'un prix et donc associé à cette CELL. |
-| « cntd »           | ***usedIn***             |                                        | *Choice*                           | 0:1             | Un élément tarifaire associé au FARE TABLE.                                    |
-| « FK »             | ***a***                  | ***TariffRef***                        | *TariffRef*                        | 1:\*            | TARIFF auquel le PRICEs of FARE TABLE s’applique.                              |
-| « FK »             | ***b***                  | ***GroupOfDistanceMatrixElementsRef*** | *GroupOfDistanceMatrixElementsRef* | 1:\*            | GROUP OF DISTANCE MATRIX ELEMENTs associé au FARE TABLE.                       |
-| « FK »             | ***c***                  | ***GroupOfSalesOfferPackagesRef***     | *GroupOfSalesOfferPackagesRef*     | 1:\*            | GROUP OF SALES OFFER PACKAGEs associé au FARE TABLE.                           |
-| « FK »             | ***OrganisationRef***    |                                        | *(OrganisationRef)*                | 0:1             | OPERATOR ou AUTHORITY auquel le FARE PRICEs s’applique.                        |
-
-<div class='table-title'>FareTableCommonAssignmentsGroup – Group</div>
-
-| **Classification** | **Name**                            | **Type**              | **Cardinality** | **Description**                                                                                    |
-|--------------------|-------------------------------------|-----------------------|-----------------|----------------------------------------------------------------------------------------------------|
-| « cntd »           | ***limitations***                   | *UsageParameterRef+*  | 0:\*            | USAGE PARAMETER or PARAMETERs auquel le CELL PRICE s’applique.                                     |
-| XGRP               | ***CellSpecificNetworkGroup***      | ***<u>xmlGroup</u>*** | 0:1             | Combinaison d'éléments liés au réseau pour lesquels la FARE TABLE ou CELL fournit un prix.         |
-| XGRP               | ***CellSpecificRoutingGroup***      | ***<u>xmlGroup</u>*** | 0:1             | Combinaison d'éléments liés à l’itinéraire pour lesquels la FARE TABLE or CELL fournit un prix.    |
-| XGRP               | ***CellSpecificServiceGroup***      | ***<u>xmlGroup</u>*** | 0:1             | Combinaison d'éléments liés aux services pour lesquels la FARE TABLE ou CELL fournit un prix.      |
-| XGRP               | ***CellSpecificDistributionGroup*** | ***<u>xmlGroup</u>*** | 0:1             | Combinaison d'éléments liés à la distribution pour lesquels la FARE TABLE ou CELL fournit un prix. |
+|     | ***Name*** (GroupOfEntitiesGroup)          | *MultilingualString*         | 0:1             |      |
+|     | ***ShortName*** (GroupOfEntitiesGroup)          | *MultilingualString*         | 0:1             |      |
+|     | ***Description*** (GroupOfEntitiesGroup)          | *MultilingualString*         | 0:1             |      |
+|     | ***PurposeOfGroupingRef*** (GroupOfEntitiesGroup)          | *PurposeOfGroupingIdType*         | 0:1             |      |
+|     | ***infoLinks*** (GroupOfEntitiesGroup)          | *InfoLink*         | 0:\*             |      |
+|     | ***StartDate*** (PriceGroup)          | *xsd:date*         | 0:1             | Date de début de validité du prix.                                                            |
+|     | ***EndDate***  (PriceGroup)            | *xsd:date*         | 0:1             | Date de fin de validité du prix.                                                              |
+|     | ***RoundingRef***  (PriceGroup)       | *RoundingId*       | 0:1             | Lien vers une description sur la méthode d'arrondie.    |
+|     | ***TypeOfFareTableRef***  (FareTableReferencesGroup)       | *TypeOfFareTableIdType*       | 0:1             |   Classification de la FARE TABLE  |
+|     | ***pricesFor***  (FareTableReferencesGroup)       | *PriceableObjectRef*       | 0:\*             | PRICEABLE OBJECT pouvant faire l'objet d'un prix et donc associé à cette CELL. (sauf qu'on est au noveau tableau)   |
+|     | ***usedIn***  (FareTableReferencesGroup)       | *special*       | 0:\*ù*             |  Elements that use FARE TABLE that are not PRICEABLE OBJECTs. Cette liste peut contenir des ***TariffRef***, ***GroupOfDistanceMatrixElementsRef*** et des ***GroupOfSalesOfferPackagesRef***  |
+|     | ***OrganisationRef***  (FareTableReferencesGroup)       | *(OrganisationRef)*       | 0:1             |  OPERATOR ou AUTHORITY auquel le FARE PRICEs s’applique. OrganisationRef est ici une référence à un objet générique, un OperatorRef ou un AuthorityRef devant être utilisé.   |
+|     | ***limitations***  (FareTableCommonAssignmentsGroup)       | *UsageParameterRef+*       | 0:\*             |  USAGE PARAMETER or PARAMETERs auquel le CELL PRICE s’applique.  |
+| XGRP               | ***CellSpecificNetworkGroup*** (FareTableCommonAssignmentsGroup)     | ***<u>xmlGroup</u>*** | 0:1             | Combinaison d'éléments liés au réseau pour lesquels la FARE TABLE ou CELL fournit un prix.         |
+| XGRP               | ***CellSpecificRoutingGroup*** (FareTableCommonAssignmentsGroup)     | ***<u>xmlGroup</u>*** | 0:1             | Combinaison d'éléments liés à l’itinéraire pour lesquels la FARE TABLE or CELL fournit un prix.    |
+| XGRP               | ***CellSpecificServiceGroup***  (FareTableCommonAssignmentsGroup)    | ***<u>xmlGroup</u>*** | 0:1             | Combinaison d'éléments liés aux services pour lesquels la FARE TABLE ou CELL fournit un prix.      |
+| XGRP               | ***CellSpecificDistributionGroup*** (FareTableCommonAssignmentsGroup)| ***<u>xmlGroup</u>*** | 0:1             | Combinaison d'éléments liés à la distribution pour lesquels la FARE TABLE ou CELL fournit un prix. |
+|     | ***columns***  (FareTableHeadingsGroup)       | *FareTableColumn*       | 0:\*             |  Column headings to use when presenting table.  |
+|     | ***rows***  (FareTableHeadingsGroup)       | *FareTableRow*       | 0:\*             |  Row headings to use when presenting table.  |
+|     | ***includes***  (FareTableHeadingsGroup)       | *FareTableRef* ou *FareTable*       | 0:\*             |  Sub tables contained in table.  |
+|     | ***EmbargoUntil***   (FareTableGroup)    | *xsd:dateTime*     | 0:1             | Les prix ne seront communiqués qu'à partir de cette date.                                     |
+| « cntd »           | ***cells***      (FareTableGroup)       | *Cell*             | 0:\*            | Un tuple dans une TABLE DES TARIFS qui associe une ou plusieurs entités tarifaires à un prix. |
+| « cntd »           | ***noticeAssignments*** (FareTableGroup)  | *NoticeAssignment* | 0:\*            | NOTICEs s’appliquant à l’ensemble de la FARE TABLE                                            |
 
 <div class='table-title'>FareTableHeadingsGroup – Group</div>
 


### PR DESCRIPTION
Je vous propose de fusionner plusieurs tableaux en un seul pour faciliter la lisibilité. Ca permet également de rendre visible des propriétés présentes dans les exemples qu'on ne voit pas dans le profil France (attribut Name par exemple, en lien avec le retour dans https://github.com/etalab/transport-profil-netex-fr/issues/158 sur FareDemandFactor ).
Je n'ai pas traduit les textes encore en anglais le temps de vérifier si cette proposition est validée.