### PR TITLE
Structure - précisions sur l'organisation des données

### DIFF
--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -4849,6 +4849,10 @@ Deux grandes typologies d’échange peuvent être envisagées : par échange
 de fichier (sous quelque forme que ce soit : FTP, mail, etc.) ou au
 travers de web service.
 
+## Règles générales
+- **Pas de duplication de ressources NeTEx** : pas de duplication des données “classe - identifiant - version” ce qui signifie que deux version différentes d’un même objet peuvent coexister
+- **Éviter les sur-informations** : éviter l’introduction de données externes impliquant des dépendances à des sources externes de donnée (ex Code SIREN pour une AOM) ou non utiles pour la définition de l’offre objet de l’archive 
+
 ## Export sous forme de fichier
 
 Un export Netex au profil France est une archive ZIP respectant plusieurs contraintes : 
@@ -4863,6 +4867,7 @@ Les noms des fichiers doivent respecter les contraintes suivantes :
 - le séparateur est “_”
 - pas d’accent
 - pas d'espace
+
 
 Chaque fichier ne contiendra qu’un seul élément racine : ***PublicationDelivery*** (voir 7.1).
 Le fichier XSD de plus haut niveau à utiliser est *NeTEx_publication.xsd*.

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -4849,14 +4849,23 @@ Deux grandes typologies d’échange peuvent être envisagées : par échange
 de fichier (sous quelque forme que ce soit : FTP, mail, etc.) ou au
 travers de web service.
 
-## Fichier
+## Export sous forme de fichier
 
-L’échange par fichier est assez simple : le fichier est un fichier XML
-classique qui ne contiendra qu’un seul élément racine :
-***PublicationDelivery*** (voir 7.1).
+Un export Netex au profil France est une archive ZIP respectant plusieurs contraintes : 
+- le nom du fichier est libre, mais il est recommander de préciser qu'il s'agit d'un fichier netex ;
+- l'archive ne ne contient pas de dossiers, tous les fichiers sont listés à la racine ; 
+- les fichiers binaires, exécutables et sous archives sont interdits ;
+- d'autres fichiers de type texte ou json peuvent figurer dans l’archive mais seront ignorés à l’import ;
+- des mesures de sécurités “propres à chaque consommateur” pourront conduire à des exigences complémentaires.
 
-Le fichier XSD de plus haut niveau à utiliser est
-*NeTEx_publication.xsd*.
+Les noms des fichiers doivent respecter les contraintes suivantes : 
+- pas de majuscule
+- le séparateur est “_”
+- pas d’accent
+- pas d'espace
+
+Chaque fichier ne contiendra qu’un seul élément racine : ***PublicationDelivery*** (voir 7.1).
+Le fichier XSD de plus haut niveau à utiliser est *NeTEx_publication.xsd*.
 
 ## Web service
 

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -4868,6 +4868,19 @@ Les noms des fichiers doivent respecter les contraintes suivantes :
 - pas d’accent
 - pas d'espace
 
+Les fichiers attendus dans l'archive sont les suivants : 
+| **Fichier** |  **Description** 
+|--------------------|--------------------------------------------|
+| accessibility.xml  | Fichier regroupant toutes les informations d'accessibilité 
+| network.xml        | Fichier regroupant les informations sur les réseaux et les groupes de lignes
+| stop.xml           | Fichier regroupant les informations sur les arrêts, les quais, etc.
+| line_XXX.xml       | Chaque fichier contient la description complète d'une ligne de transport en commun 
+(parcours, courses, horaires, etc.). La partie "XXX" du nom de fichier est laissée libre, à condition de respecter l'unicité et les contraintes associées aux noms de fichiers. Il est recommandé d'utiliser des libéllés courts comme les codes des lignes par exemple.
+| fare.xml           | Fichier regroupant les informations sur les tarifs, que ce soit pour les transports en commun, les parkings ou autres.
+| parking.xml        | Fichier regroupant les informations sur les parkings.
+| poi.xml            | Fichier regroupant les points d'intérêts et les informations associées
+| resource.xml       | Fichier contenant toutes les informations qui ne sont pas collectés dans des fichiers thématiques 
+(correspondances, calendriers, commentaires, etc.)
 
 Chaque fichier ne contiendra qu’un seul élément racine : ***PublicationDelivery*** (voir 7.1).
 Le fichier XSD de plus haut niveau à utiliser est *NeTEx_publication.xsd*.


### PR DESCRIPTION
Travail en cours dans des commit séparés pour faciliter la relecture (si besoin).
A vérifier : 
- nous avions convenu que les noms des fichiers ne devaient pas avoir de majuscule, mais tous les travaux indiquent des majuscules. J'ai donc tout repassé en minuscule, à valider ensemble. Je me suis permis d'assouplir la règle sur les compléments des noms des fichiers de ligne, a regarder également.
- Le profil propose des exports sous forme de web service, mais nous travaillons sur des fichiers ZIP pour alimenter le PAN. Est-ce que nous supprimons cette possibilité (qui peut continuer à exister en dehors du profil France) ?