### PR TITLE
Précisions sur les RouteLink et ServiceLink

### DIFF
--- a/NeTEx/horaires/index.md
+++ b/NeTEx/horaires/index.md
@@ -2162,6 +2162,9 @@ dans les éléments ***members*** du ***GeneralFrame***.
 <li><p><span class="hl">SERVICE JOURNEY</span></p></li>
 </ul>
 <ul>
+<li><p><span class="hl">SERVICE LINK</span></p></li>
+</ul>
+<ul>
 <li><p><span class="hl">FLEXIBLE SERVICE PROPERTIES</span></p></li>
 </ul>
 <ul>

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -1268,7 +1268,7 @@ Exemple :
 
 Exemple de LineString pour décrire un tracé : 
 ```xml
-<gml:LineString srsName="WGS84" gml:id="AB2o"> 
+<gml:LineString gml:id="AB2o"> 
     <gml:pos>53.00 1.00</gml:pos> 
     <gml:pos>53.10 1.10</gml:pos> 
     <gml:pos>53.20 1.20</gml:pos> 

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -1260,9 +1260,19 @@ Exemple :
 |---------------------|--------------------|-----------------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | *::>*               | *::>*              | *Link*          | *::>*            | ROUTE LINK hérite de LINK <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span>. |
 |                     | Distance           | DistanceType    | 1:1              | Longueur du ROUTE LINK. Les unités sont telles que spécifiées pour la FRAME (la valeur par défaut est SI mètres).                                                                         |
+| «cntd»              | LineString         | gmlLineString   | 0:1              | Géométrie du TRONÇON sous forme d’une linestring GML (la géométrie d’un TRONÇON n’est donc pas limitée à un simple couple de point, mais est décrite par une séquence de points).  |
 | «FK»                | ***FromPointRef*** | *RoutePointRef* | 1:1              | POINT D'ITINÉRAIRE de début de <span class="hl">TRONÇON</span>.                                                                                                                         |
 | «FK»                | ***ToPointRef***   | *RoutePointRef* | 1:1              | POINT D'ITINÉRAIRE de fin de <span class="hl">TRONÇON</span>.                                                                                                                           |
 |                     |                    |                 |                  |                                                                                                                                                                                           |
+
+Exemple de LineString pour décrire un tracé : 
+```xml
+<gml:LineString srsName="WGS84" gml:id="AB2o"> 
+    <gml:pos>53.00 1.00</gml:pos> 
+    <gml:pos>53.10 1.10</gml:pos> 
+    <gml:pos>53.20 1.20</gml:pos> 
+</gml:LineString>
+```
 
 ## Les affichages de destination
 

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -1219,6 +1219,7 @@ Exemple :
 |                     | ***DirectionType***    | *TypeOfDirectionEnum* | 0:1              | Type de direction de la ROUTE (***outbound***, ***inbound***, pour aller Retrour et éventuellement ***clockwise*** ou ***anticlockwise*** pour les boucles)                                   |
 | «FK»                | ***DirectionRef***     | *DirectionRef*        | 0:1              | Référence la DIRECTION de l'ITINÉRAIRE.                                                                                                                                                       |
 | «cntd»              | ***pointsInSequence*** | *PointOnRoute*        | 2:\*             | Liste des points de l'ITINÉRAIRE.                                                                                                                                                             |
+| «cntd»              | ***sectionsInSequence*** | *SectionLink*        | 0:\*             | Liste des sections de l'ITINÉRAIRE.                                                                                                                                                             |
 |                     | ***InverseRouteRef***  | *RouteRef*            | 0:1              | Référence l'éventuel ITINÉRAIRE en sens opposé.                                                                                                                                               |
 
 ### Les Point d'itinéraire
@@ -1853,13 +1854,6 @@ flexibilité.
 <td>0:1</td>
 <td>AFFICHAGE DE DESTINATION associée à la MISSION COMMERCIALE <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
 </tr>
-
-
-
-
-
-
-
 <tr class="even">
 <td>«cntd»</td>
 <td><em><strong>pointsInSequence</strong></em></td>
@@ -1867,7 +1861,14 @@ flexibilité.
 <td>0:*</td>
 <td>Liste ordonnées des points sur la MISSION COMMERCIALE (POINT D'ARRÊT SUR PARCOURS, POINT HORAIRE ou POINT SUR PARCOURS).</td>
 </tr>
-
+<tr class="even">
+<td>«cntd»</td>
+<td><em><strong>linksInSequence</strong></em></td>
+<td><em>ServiceLink</em></td>
+<td>0:*</td>
+<td>
+Liste ordonnées des sections de la MISSION COMMERCIALE (SERVICE LINK). Chaque section décrit la géométrie entre deux points consécutifs (ScheduleStopPoint).</td>
+</tr>
 <tr class="even">
 <td>«FK»</td>
 <td><em><strong>ServiceJourneyPatternType</strong></em></td>
@@ -3625,6 +3626,10 @@ Le présent profil utilise un *TypeOfFrame* spécifique, identifié
 </ul>
 <ul>
 <li><p><span class="hl">POINT IN JOURNEY PATTERN</span></p></li>
+</ul>
+</ul>
+<ul>
+<li><p><span class="hl">SERVICE LINK</span></p></li>
 </ul>
 <ul>
 <li><p><span class="hl">SCHEDULED STOP POINT</span></p></li>

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -1222,7 +1222,7 @@ Exemple :
 | «cntd»              | ***sectionsInSequence*** | *SectionLink*        | 0:\*             | Liste des sections de l'ITINÉRAIRE.                                                                                                                                                             |
 |                     | ***InverseRouteRef***  | *RouteRef*            | 0:1              | Référence l'éventuel ITINÉRAIRE en sens opposé.                                                                                                                                               |
 
-### Les Point d'itinéraire
+### Les Points d'itinéraire
 
 <div class="table-title">RoutePoint – Element</div>
 
@@ -1859,7 +1859,7 @@ flexibilité.
 <td><em><strong>pointsInSequence</strong></em></td>
 <td><em>PointInJourneyPattern</em></td>
 <td>0:*</td>
-<td>Liste ordonnées des points sur la MISSION COMMERCIALE (POINT D'ARRÊT SUR PARCOURS, POINT HORAIRE ou POINT SUR PARCOURS).</td>
+<td>Liste ordonnée des points sur la MISSION COMMERCIALE (POINT D'ARRÊT SUR PARCOURS, POINT HORAIRE ou POINT SUR PARCOURS).</td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>
@@ -1867,7 +1867,7 @@ flexibilité.
 <td><em>ServiceLink</em></td>
 <td>0:*</td>
 <td>
-Liste ordonnées des sections de la MISSION COMMERCIALE (SERVICE LINK). Chaque section décrit la géométrie entre deux points consécutifs (ScheduleStopPoint).</td>
+Liste ordonnée des sections de la MISSION COMMERCIALE (SERVICE LINK). Chaque section décrit la géométrie entre deux points consécutifs (ScheduleStopPoint).</td>
 </tr>
 <tr class="even">
 <td>«FK»</td>


### PR DESCRIPTION
Suite à la discussions Slack et à l'issue https://github.com/etalab/transport-profil-netex-fr/issues/182, voilà une PR pour : 
- Ajouter le SERVICE LINK dans la Frame Horaire (avec les courses et les missions qui peuvent l'utiliser)
- la propriété sectionsInSequence de la Route pour indiquer des RouteSection
- Ajout de la propriété LineString sur la RouteSection, avec un exemple de gml
- Ajout de la propriété linksInSequence sur la mission (ServiceJourneyPattern). Je ne l'ai pas fait pour la course, alors qu'elle peut également avoir les ServiceLink. A vérifier s'il est interessant de les ajouter.

N'hésitez pas à vérifier les types d'objets, j'ai eu du mal à m'y retrouver dans les héritages !