### PR TITLE
Déplace la note concernant le surlignage jaune vers "top level"

### DIFF
--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -753,9 +753,9 @@ proposent ces colonnes:
     modification (ceci explique notamment que tous les commentaires soient
     en anglais).
 
-Les textes surlignés en <span class="hl">Jaune</span> sont ceux
-présentant une particularité (spécialisation) par rapport à NeTEx: une
-codification particulière, une restriction d'usage, etc.
+Les textes surlignés en <span class="hl">jaune</span> sont ceux
+présentant une particularité (spécialisation du profil France) par rapport à NeTEx : une
+codification particulière, une restriction d'usage, un changement de cardinalité, etc.
 
 **Les attributs et éléments rendus obligatoires dans le cadre de ce profil restent facultatifs dans l'XSD (le contrôle de cardinalité devra donc être réalisé applicativement).**
 

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -749,13 +749,13 @@ proposent ces colonnes:
     
     Seuls les attributs retenus par le profil ont un texte en français.
 
-    Les textes surlignés en <span class="hl">Jaune</span> sont ceux
-    présentant une particularité (spécialisation) par rapport à NeTEx: une
-    codification particulière, une restriction d'usage, etc.
-
     La description XSD utilisée est strictement celle de NeTEx, sans aucune
     modification (ceci explique notamment que tous les commentaires soient
     en anglais).
+
+Les textes surlignés en <span class="hl">Jaune</span> sont ceux
+présentant une particularité (spécialisation) par rapport à NeTEx: une
+codification particulière, une restriction d'usage, etc.
 
 **Les attributs et éléments rendus obligatoires dans le cadre de ce profil restent facultatifs dans l'XSD (le contrôle de cardinalité devra donc être réalisé applicativement).**
 


### PR DESCRIPTION
Juste après le merge de:
- #207 

où j'avais un doute sur le formatage, je vois que la note concernant le "surligné jaune" semble portée par la "Description". 

<img width="1390" height="636" alt="CleanShot 2025-08-22 at 17 20 25@2x" src="https://github.com/user-attachments/assets/26966cf1-98a8-4d67-af66-6a36c1861990" />

En pratique toutefois on retrouve ce surligné ailleurs (cardinalités, voire type), donc je propose de le remettre au niveau "racine" et plus sur la liste.

(il faudra vérifier le rendu).