### PR TITLE
Ajouts d'exemples issus d'AccèsLibre Mobilités

### DIFF
--- a/exemples/AccesLibreMobilites/ALM_onstreetbus_example/accessibility.xml
+++ b/exemples/AccesLibreMobilites/ALM_onstreetbus_example/accessibility.xml
@@ -1,0 +1,2766 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_ACCESSIBILITY:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_ACCESSIBILITY:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <SitePathLink id="ALM:SitePathLink:w32_n26_n37:LOC" version="2">
+          <Distance>1083.43</Distance>
+          <gml:LineString gml:id="w32_n26_n37">
+            <gml:pos>2.6499866 48.8388332</gml:pos>
+            <gml:pos>2.6499873 48.8388083</gml:pos>
+            <gml:pos>2.649993 48.8387712</gml:pos>
+            <gml:pos>2.6500346 48.8384997</gml:pos>
+            <gml:pos>2.6500865 48.8381615</gml:pos>
+            <gml:pos>2.6501997 48.8376265</gml:pos>
+            <gml:pos>2.6502777 48.8375139</gml:pos>
+            <gml:pos>2.6514955 48.8369876</gml:pos>
+            <gml:pos>2.6519487 48.8367917</gml:pos>
+            <gml:pos>2.6523939 48.8365902</gml:pos>
+            <gml:pos>2.6528748 48.8363726</gml:pos>
+            <gml:pos>2.653285 48.836371</gml:pos>
+            <gml:pos>2.6536499 48.8362832</gml:pos>
+            <gml:pos>2.6538663 48.8361557</gml:pos>
+            <gml:pos>2.6540751 48.8359503</gml:pos>
+            <gml:pos>2.6541842 48.835854</gml:pos>
+            <gml:pos>2.6543545 48.8357035</gml:pos>
+            <gml:pos>2.6545155 48.8356422</gml:pos>
+            <gml:pos>2.6545363 48.835648</gml:pos>
+            <gml:pos>2.6547302 48.8357016</gml:pos>
+            <gml:pos>2.6549161 48.8358105</gml:pos>
+            <gml:pos>2.6556716 48.8362768</gml:pos>
+            <gml:pos>2.6556605 48.8365207</gml:pos>
+            <gml:pos>2.6554794 48.8369739</gml:pos>
+            <gml:pos>2.65519 48.8372306</gml:pos>
+            <gml:pos>2.6532924 48.838082</gml:pos>
+            <gml:pos>2.6522909 48.8385508</gml:pos>
+            <gml:pos>2.6520695 48.838665</gml:pos>
+            <gml:pos>2.6517902 48.8388969</gml:pos>
+            <gml:pos>2.6516844 48.8389974</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n26:LOC" version="2"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n37:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:10:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w145_n117_n832:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>8.59</Distance>
+          <gml:LineString gml:id="w145_n117_n832">
+            <gml:pos>2.6545379 48.835577</gml:pos>
+            <gml:pos>2.6545608037 48.83556530151</gml:pos>
+            <gml:pos>2.65464775665 48.83557574592</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n117:LOC" version="3"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n832:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:11:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>2</Gradient>
+          <GradientType>gentle</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>pavement</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w146_n825_n843:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Pedestrian</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>3.2</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>26.47</Distance>
+          <gml:LineString gml:id="w146_n825_n843">
+            <gml:pos>2.65303730696 48.83456690843</gml:pos>
+            <gml:pos>2.65290319651 48.83448922527</gml:pos>
+            <gml:pos>2.6530185315 48.83439565222</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n825:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n843:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:12:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>3.20</MinimumWidth>
+          <Gradient>3</Gradient>
+          <GradientType>medium</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w149_n882_n847:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>10</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>15.44</Distance>
+          <gml:LineString gml:id="w149_n882_n847">
+            <gml:pos>2.65630625121 48.83611613128</gml:pos>
+            <gml:pos>2.65646199243 48.83602246212</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n882:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:Entrance:n847:LOC" versionRef="1"/>
+            <EntranceRef ref="ALM:Entrance:n847:LOC" versionRef="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:13:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>10.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>openSpace</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>concrete</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w150_n839_n120:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>7.84</Distance>
+          <gml:LineString gml:id="w150_n839_n120">
+            <gml:pos>2.65574298732 48.83622691442</gml:pos>
+            <gml:pos>2.65577718548 48.83625030685</gml:pos>
+            <gml:pos>2.6558197 48.8362245</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n839:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n120:LOC" version="3"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:14:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtEnd</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w151_n813_n833:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualGuidanceBands</Key>
+              <Value>No</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>18.26</Distance>
+          <gml:LineString gml:id="w151_n813_n833">
+            <gml:pos>2.65592711678 48.83663726109</gml:pos>
+            <gml:pos>2.65614464812 48.83671771169</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n813:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n833:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:15:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>crossing</AccessFeatureType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <placeEquipments>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w151_n813_n833:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w152_n122_n878:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Discomfortable</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>113.10</Distance>
+          <gml:LineString gml:id="w152_n122_n878">
+            <gml:pos>2.6547723 48.83548</gml:pos>
+            <gml:pos>2.65485015199 48.8355229844</gml:pos>
+            <gml:pos>2.65565746015 48.83596872112</gml:pos>
+            <gml:pos>2.65595622228 48.83613367478</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n122:LOC" version="3"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n878:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:16:" version="any">
+            <validityConditions>
+              <ValidityCondition id="ALM:ValidityCondition:16:" version="any">
+                <Description>Secousses du fait de la présence de racine sous le revêtement</Description>
+              </ValidityCondition>
+            </validityConditions>
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>partial</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>2</Gradient>
+          <GradientType>gentle</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>pavement</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w153_n840_n824:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>26.12</Distance>
+          <gml:LineString gml:id="w153_n840_n824">
+            <gml:pos>2.65371590585 48.83508420457</gml:pos>
+            <gml:pos>2.65399485558 48.83523074141</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n840:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n824:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:17:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>2</Gradient>
+          <GradientType>gentle</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>pavement</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w154_n868_n114:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>2</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>39.88</Distance>
+          <gml:LineString gml:id="w154_n868_n114">
+            <gml:pos>2.6545608037 48.83556530151</gml:pos>
+            <gml:pos>2.6549343013 48.83579349054</gml:pos>
+            <gml:pos>2.6549329602 48.83580364206</gml:pos>
+            <gml:pos>2.6549161 48.8358105</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n868:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n114:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:18:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>2.00</MinimumWidth>
+          <Gradient>3</Gradient>
+          <GradientType>gentle</GradientType>
+          <AccessFeatureType>ramp</AccessFeatureType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <placeEquipments>
+            <RampEquipmentRef ref="ALM:RampEquipment:w154_n868_n114:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w155_n880_n825:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>6</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Place Gaston Deffere</Name>
+          <Distance>75.71</Distance>
+          <gml:LineString gml:id="w155_n880_n825">
+            <gml:pos>2.65385538071 48.83498357058</gml:pos>
+            <gml:pos>2.65381425727 48.83496262563</gml:pos>
+            <gml:pos>2.65333090281 48.83471644337</gml:pos>
+            <gml:pos>2.65303730696 48.83456690843</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n880:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n825:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:19:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>6.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>openSpace</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>concrete</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w156_n122_n880:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>86.90</Distance>
+          <gml:LineString gml:id="w156_n122_n880">
+            <gml:pos>2.6547723 48.83548</gml:pos>
+            <gml:pos>2.65462481473 48.83540029175</gml:pos>
+            <gml:pos>2.65407010436 48.83509934589</gml:pos>
+            <gml:pos>2.6539412114 48.83502947383</gml:pos>
+            <gml:pos>2.65385538071 48.83498357058</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n122:LOC" version="3"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n880:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:20:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>2</Gradient>
+          <GradientType>gentle</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>pavement</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtBeginning</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w157_n846_n794:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>28.01</Distance>
+          <gml:LineString gml:id="w157_n846_n794">
+            <gml:pos>2.65342391902 48.83517540352</gml:pos>
+            <gml:pos>2.65346646041 48.83514423176</gml:pos>
+            <gml:pos>2.65348523587 48.83517071432</gml:pos>
+            <gml:pos>2.65366226166 48.83510009412</gml:pos>
+            <gml:pos>2.65369981259 48.83513716974</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:Entrance:n846:LOC" versionRef="1"/>
+            <EntranceRef ref="ALM:Entrance:n846:LOC" versionRef="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:ParkingBay:n794:LOC" versionRef="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:21:" version="any">
+            <MobilityImpairedAccess>true</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>true</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <TactileGuidingStrip>true</TactileGuidingStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w158_n856_n841:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>37.43</Distance>
+          <gml:LineString gml:id="w158_n856_n841">
+            <gml:pos>2.65407010436 48.83509934589</gml:pos>
+            <gml:pos>2.65448936481 48.83490667093</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n856:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:Entrance:n841:LOC" versionRef="1"/>
+            <EntranceRef ref="ALM:Entrance:n841:LOC" versionRef="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:22:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w159_n823_n813:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>4.48</Distance>
+          <gml:LineString gml:id="w159_n823_n813">
+            <gml:pos>2.65587374501 48.83661752235</gml:pos>
+            <gml:pos>2.65592711678 48.83663726109</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n823:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n813:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:23:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>2</Gradient>
+          <GradientType>gentle</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>pavement</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtEnd</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w160_n858_n868:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>48.32</Distance>
+          <gml:LineString gml:id="w160_n858_n868">
+            <gml:pos>2.65406727523 48.83527664443</gml:pos>
+            <gml:pos>2.6545608037 48.83556530151</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n858:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n868:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:24:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>2</Gradient>
+          <GradientType>gentle</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>pavement</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w161_n122_n121:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualGuidanceBands</Key>
+              <Value>No</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>11.59</Distance>
+          <gml:LineString gml:id="w161_n122_n121">
+            <gml:pos>2.6547723 48.83548</gml:pos>
+            <gml:pos>2.654666 48.8355572</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n122:LOC" version="3"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n121:LOC" version="3"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:25:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>crossing</AccessFeatureType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <placeEquipments>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w161_n122_n121:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w162_n855_n801:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualGuidanceBands</Key>
+              <Value>No</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>9.50</Distance>
+          <gml:LineString gml:id="w162_n855_n801">
+            <gml:pos>2.65303194255 48.83494649485</gml:pos>
+            <gml:pos>2.65311240882 48.83501358425</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n855:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n801:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:26:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>crossing</AccessFeatureType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <placeEquipments>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w162_n855_n801:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w163_n833_n817:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>71.13</Distance>
+          <gml:LineString gml:id="w163_n833_n817">
+            <gml:pos>2.65614464812 48.83671771169</gml:pos>
+            <gml:pos>2.65637867086 48.83665018321</gml:pos>
+            <gml:pos>2.65658654206 48.83652571872</gml:pos>
+            <gml:pos>2.65668444268 48.83639684028</gml:pos>
+            <gml:pos>2.65677295558 48.83632887001</gml:pos>
+            <gml:pos>2.65672132306 48.83628826434</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n833:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n817:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:27:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>gentle</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>pavement</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w164_n840_n870:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>10</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Place Gaston Deffere</Name>
+          <Distance>5.53</Distance>
+          <gml:LineString gml:id="w164_n840_n870">
+            <gml:pos>2.65371590585 48.83508420457</gml:pos>
+            <gml:pos>2.65373736352 48.83503653586</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n840:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n870:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:28:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>10.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>openSpace</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>concrete</FlooringType>
+          <TactileWarningStrip>tactileStripAtEnd</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w165_n824_n808:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>4.52</Distance>
+          <gml:LineString gml:id="w165_n824_n808">
+            <gml:pos>2.65399485558 48.83523074141</gml:pos>
+            <gml:pos>2.65394389361 48.83525369292</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n824:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:ParkingBay:n808:LOC" versionRef="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:29:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w167_n73_n839:LOC" version="1">
+          <Distance>7.62</Distance>
+          <gml:LineString gml:id="w167_n73_n839">
+            <gml:pos>2.6556716 48.8362768</gml:pos>
+            <gml:pos>2.65574298732 48.83622691442</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n73:LOC" version="2"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n839:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:30:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Transition>up</Transition>
+          <AccessFeatureType>stairs</AccessFeatureType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <placeEquipments>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w167_n73_n839:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w168_n800_n878:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>10</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>60.31</Distance>
+          <gml:LineString gml:id="w168_n800_n878">
+            <gml:pos>2.65667237274 48.83623838995</gml:pos>
+            <gml:pos>2.65660196476 48.83615938529</gml:pos>
+            <gml:pos>2.65648864143 48.83618145364</gml:pos>
+            <gml:pos>2.65630625121 48.83611613128</gml:pos>
+            <gml:pos>2.65602864258 48.83615011657</gml:pos>
+            <gml:pos>2.65595622228 48.83613367478</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n800:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n878:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:31:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>10.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>openSpace</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>concrete</FlooringType>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w169_n815_n798:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>10</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Place Gaston Deffere</Name>
+          <Distance>3.48</Distance>
+          <gml:LineString gml:id="w169_n815_n798">
+            <gml:pos>2.65378832549 48.83498886711</gml:pos>
+            <gml:pos>2.65381425727 48.83496262563</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n815:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n798:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:32:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>10.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>openSpace</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>concrete</FlooringType>
+          <TactileWarningStrip>tactileStripAtBeginning</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w170_n118_n117:LOC" version="1">
+          <Distance>7.90</Distance>
+          <gml:LineString gml:id="w170_n118_n117">
+            <gml:pos>2.6545363 48.835648</gml:pos>
+            <gml:pos>2.6545379 48.835577</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n118:LOC" version="3"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n117:LOC" version="3"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:33:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>8</NumberOfSteps>
+          <Transition>up</Transition>
+          <AccessFeatureType>stairs</AccessFeatureType>
+          <TactileWarningStrip>noTactileStrip</TactileWarningStrip>
+          <placeEquipments>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w170_n118_n117:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w171_n811_n859:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Bicycle</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>3.2</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>159.36</Distance>
+          <gml:LineString gml:id="w171_n811_n859">
+            <gml:pos>2.65485015199 48.8355229844</gml:pos>
+            <gml:pos>2.65497386187 48.83537551233</gml:pos>
+            <gml:pos>2.65515625209 48.83508067355</gml:pos>
+            <gml:pos>2.65524476498 48.83481584683</gml:pos>
+            <gml:pos>2.65527426928 48.83452806687</gml:pos>
+            <gml:pos>2.65529036254 48.83414141512</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n811:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n859:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:34:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>3.20</MinimumWidth>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w174_n74_n823:LOC" version="1">
+          <Distance>18.96</Distance>
+          <gml:LineString gml:id="w174_n74_n823">
+            <gml:pos>2.6556605 48.8365207</gml:pos>
+            <gml:pos>2.65587374501 48.83661752235</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n74:LOC" version="2"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n823:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:35:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Transition>up</Transition>
+          <AccessFeatureType>stairs</AccessFeatureType>
+          <TactileWarningStrip>noTactileStrip</TactileWarningStrip>
+          <placeEquipments>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w174_n74_n823:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w175_n120_n823:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>44.81</Distance>
+          <gml:LineString gml:id="w175_n120_n823">
+            <gml:pos>2.6558197 48.8362245</gml:pos>
+            <gml:pos>2.65584088795 48.83623838995</gml:pos>
+            <gml:pos>2.65582412414 48.83638359932</gml:pos>
+            <gml:pos>2.65587642722 48.83653940101</gml:pos>
+            <gml:pos>2.65587374501 48.83661752235</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n120:LOC" version="3"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n823:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:36:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>2</Gradient>
+          <GradientType>gentle</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>pavement</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtBeginning</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w176_n824_n858:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualGuidanceBands</Key>
+              <Value>No</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>7.36</Distance>
+          <gml:LineString gml:id="w176_n824_n858">
+            <gml:pos>2.65399485558 48.83523074141</gml:pos>
+            <gml:pos>2.65406727523 48.83527664443</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n824:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n858:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:37:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>crossing</AccessFeatureType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>noTactileStrip</TactileWarningStrip>
+          <placeEquipments>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w176_n824_n858:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w177_n121_n120:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>114.53</Distance>
+          <gml:LineString gml:id="w177_n121_n120">
+            <gml:pos>2.654666 48.8355572</gml:pos>
+            <gml:pos>2.65464775665 48.83557574592</gml:pos>
+            <gml:pos>2.65543949937 48.83601309759</gml:pos>
+            <gml:pos>2.6558197 48.8362245</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n121:LOC" version="3"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n120:LOC" version="3"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:38:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>2</Gradient>
+          <GradientType>gentle</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>pavement</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:380" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n803_38_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:ShelterEquipment:n803:LOC" version="1"/>
+                  <Location id="n803">
+                    <Longitude>2.65543949937</Longitude>
+                    <Latitude>48.83601309759</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:381" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n803_38_1:LOC" version="any">
+                  <EquipmentRef ref="ALM:RubbishDisposalEquipment:n803:LOC" version="1"/>
+                  <Location id="n803">
+                    <Longitude>2.65543949937</Longitude>
+                    <Latitude>48.83601309759</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:382" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n803_38_2:LOC" version="any">
+                  <EquipmentRef ref="ALM:SeatingEquipment:n803:LOC" version="1"/>
+                  <Location id="n803">
+                    <Longitude>2.65543949937</Longitude>
+                    <Latitude>48.83601309759</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w178_n827_n855:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Bicycle</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>42.73</Distance>
+          <gml:LineString gml:id="w178_n827_n855">
+            <gml:pos>2.65333090281 48.83471644337</gml:pos>
+            <gml:pos>2.65294879407 48.83488999845</gml:pos>
+            <gml:pos>2.65303194255 48.83494649485</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n827:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n855:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:39:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtEnd</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w179_n120_n878:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualGuidanceBands</Key>
+              <Value>No</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>14.21</Distance>
+          <gml:LineString gml:id="w179_n120_n878">
+            <gml:pos>2.6558197 48.8362245</gml:pos>
+            <gml:pos>2.65595622228 48.83613367478</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n120:LOC" version="3"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n878:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:40:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>2</Gradient>
+          <GradientType>gentle</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>crossing</AccessFeatureType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <placeEquipments>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w179_n120_n878:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w180_n801_n840:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>13</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Place Gaston Deffere</Name>
+          <Distance>46.44</Distance>
+          <gml:LineString gml:id="w180_n801_n840">
+            <gml:pos>2.65311240882 48.83501358425</gml:pos>
+            <gml:pos>2.65315800637 48.83504183239</gml:pos>
+            <gml:pos>2.65338867635 48.83502594281</gml:pos>
+            <gml:pos>2.65357643098 48.83505065993</gml:pos>
+            <gml:pos>2.65371590585 48.83508420457</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n801:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n840:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:41:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>13.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>openSpace</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>concrete</FlooringType>
+          <TactileWarningStrip>tactileStripAtBeginning</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w181_n831_n805:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>13</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Place Gaston Deffere</Name>
+          <Distance>13.15</Distance>
+          <gml:LineString gml:id="w181_n831_n805">
+            <gml:pos>2.65346646041 48.83514423176</gml:pos>
+            <gml:pos>2.65357643098 48.83505065993</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n831:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n805:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:42:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>13.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>openSpace</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>concrete</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w182_n877_n816:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>34.26</Distance>
+          <gml:LineString gml:id="w182_n877_n816">
+            <gml:pos>2.65462481473 48.83540029175</gml:pos>
+            <gml:pos>2.65480784715 48.83527275441</gml:pos>
+            <gml:pos>2.65472843088 48.83522337452</gml:pos>
+            <gml:pos>2.6547919455 48.83517932255</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n877:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:Entrance:n816:LOC" versionRef="1"/>
+            <EntranceRef ref="ALM:Entrance:n816:LOC" versionRef="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:43:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w183_n884_n867:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1.5</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>13.18</Distance>
+          <gml:LineString gml:id="w183_n884_n867">
+            <gml:pos>2.654018469 48.83580755582</gml:pos>
+            <gml:pos>2.6541842 48.835854</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:Entrance:n884:LOC" versionRef="1"/>
+            <EntranceRef ref="ALM:Entrance:n884:LOC" versionRef="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n867:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:44:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>1.50</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w184_n817_n800:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualGuidanceBands</Key>
+              <Value>No</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>6.60</Distance>
+          <gml:LineString gml:id="w184_n817_n800">
+            <gml:pos>2.65672132306 48.83628826434</gml:pos>
+            <gml:pos>2.65667237274 48.83623838995</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n817:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n800:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:45:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>crossing</AccessFeatureType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <placeEquipments>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w184_n817_n800:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w185_n870_n815:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualGuidanceBands</Key>
+              <Value>No</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>6.48</Distance>
+          <gml:LineString gml:id="w185_n870_n815">
+            <gml:pos>2.65373736352 48.83503653586</gml:pos>
+            <gml:pos>2.65378832549 48.83498886711</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n870:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n815:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:46:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>crossing</AccessFeatureType>
+          <FlooringType>asphalt</FlooringType>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <placeEquipments>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w185_n870_n815:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <EntranceEquipment id="ALM:EntranceEquipment:n816:LOC" version="1">
+          <Width>1.00</Width>
+          <Door>true</Door>
+          <DoorHandleOutside>knob</DoorHandleOutside>
+          <DoorHandleInside>crashBar</DoorHandleInside>
+          <RevolvingDoor>false</RevolvingDoor>
+          <DropKerbOutside>false</DropKerbOutside>
+          <WheelchairPassable>true</WheelchairPassable>
+          <DoorstepMark>false</DoorstepMark>
+          <NecessaryForceToOpen>unknown</NecessaryForceToOpen>
+          <RampDoorbell>true</RampDoorbell>
+          <Recognizable>false</Recognizable>
+          <TurningSpacePosition>outside</TurningSpacePosition>
+          <WheelchairTurningCircle>1.00</WheelchairTurningCircle>
+        </EntranceEquipment>
+        <EntranceEquipment id="ALM:EntranceEquipment:n841:LOC" version="1">
+          <Width>1.00</Width>
+          <Door>true</Door>
+          <RevolvingDoor>false</RevolvingDoor>
+          <DropKerbOutside>false</DropKerbOutside>
+          <WheelchairPassable>true</WheelchairPassable>
+          <DoorstepMark>false</DoorstepMark>
+          <NecessaryForceToOpen>unknown</NecessaryForceToOpen>
+        </EntranceEquipment>
+        <EntranceEquipment id="ALM:EntranceEquipment:n846:LOC" version="1">
+          <Width>1.00</Width>
+          <Door>true</Door>
+          <RevolvingDoor>false</RevolvingDoor>
+          <DropKerbOutside>false</DropKerbOutside>
+          <AutomaticDoor>true</AutomaticDoor>
+          <WheelchairPassable>true</WheelchairPassable>
+          <DoorstepMark>false</DoorstepMark>
+          <NecessaryForceToOpen>noForce</NecessaryForceToOpen>
+        </EntranceEquipment>
+        <EntranceEquipment id="ALM:EntranceEquipment:n847:LOC" version="1">
+          <Width>2.00</Width>
+          <DropKerbOutside>false</DropKerbOutside>
+          <WheelchairPassable>false</WheelchairPassable>
+          <DoorstepMark>false</DoorstepMark>
+          <NecessaryForceToOpen>unknown</NecessaryForceToOpen>
+        </EntranceEquipment>
+        <EntranceEquipment id="ALM:EntranceEquipment:n884:LOC" version="1">
+          <Width>1.00</Width>
+          <Door>true</Door>
+          <RevolvingDoor>false</RevolvingDoor>
+          <DropKerbOutside>false</DropKerbOutside>
+          <WheelchairPassable>true</WheelchairPassable>
+          <DoorstepMark>false</DoorstepMark>
+          <NecessaryForceToOpen>unknown</NecessaryForceToOpen>
+        </EntranceEquipment>
+        <ShelterEquipment id="ALM:ShelterEquipment:n803:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AudibleSignals</Key>
+              <Value>No</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Name</Key>
+              <Value>Lycée Jean Moulin</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Quay</Key>
+              <Value>Bus</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>RubbishDisposal</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Seating</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Shelter</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualSigns</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>WheelchairAccess</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+        </ShelterEquipment>
+        <SeatingEquipment id="ALM:SeatingEquipment:n803:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AudibleSignals</Key>
+              <Value>No</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Name</Key>
+              <Value>Lycée Jean Moulin</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Quay</Key>
+              <Value>Bus</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>RubbishDisposal</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Seating</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Shelter</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualSigns</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>WheelchairAccess</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+        </SeatingEquipment>
+        <RubbishDisposalEquipment id="ALM:RubbishDisposalEquipment:n803:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AudibleSignals</Key>
+              <Value>No</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Name</Key>
+              <Value>Lycée Jean Moulin</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Quay</Key>
+              <Value>Bus</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>RubbishDisposal</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Seating</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Shelter</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualSigns</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>WheelchairAccess</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+        </RubbishDisposalEquipment>
+        <CrossingEquipment id="ALM:CrossingEquipment:w151_n813_n833:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+          </keyList>
+          <DirectionOfUse>both</DirectionOfUse>
+          <CrossingType>roadCrossingWithIsland</CrossingType>
+          <ZebraCrossing>true</ZebraCrossing>
+          <AcousticCrossingAids>false</AcousticCrossingAids>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <VisualGuidanceBands>false</VisualGuidanceBands>
+          <DroppedKerb>true</DroppedKerb>
+          <MarkingStatus>good</MarkingStatus>
+        </CrossingEquipment>
+        <RampEquipment id="ALM:RampEquipment:w154_n868_n114:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+          </keyList>
+          <Width>2.00</Width>
+          <Length>39.88</Length>
+          <MaximumLoad>200</MaximumLoad>
+          <Gradient>3</Gradient>
+          <GradientType>gentle</GradientType>
+          <HandrailType>none</HandrailType>
+          <Temporary>false</Temporary>
+          <RestStopDistance>1</RestStopDistance>
+          <SafetyEdge>oneSide</SafetyEdge>
+        </RampEquipment>
+        <CrossingEquipment id="ALM:CrossingEquipment:w161_n122_n121:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+          </keyList>
+          <DirectionOfUse>both</DirectionOfUse>
+          <CrossingType>roadCrossing</CrossingType>
+          <ZebraCrossing>true</ZebraCrossing>
+          <AcousticCrossingAids>false</AcousticCrossingAids>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <VisualGuidanceBands>false</VisualGuidanceBands>
+          <DroppedKerb>true</DroppedKerb>
+          <MarkingStatus>good</MarkingStatus>
+        </CrossingEquipment>
+        <CrossingEquipment id="ALM:CrossingEquipment:w162_n855_n801:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+          </keyList>
+          <DirectionOfUse>both</DirectionOfUse>
+          <CrossingType>roadCrossing</CrossingType>
+          <ZebraCrossing>true</ZebraCrossing>
+          <AcousticCrossingAids>false</AcousticCrossingAids>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <VisualGuidanceBands>false</VisualGuidanceBands>
+          <DroppedKerb>true</DroppedKerb>
+          <MarkingStatus>good</MarkingStatus>
+        </CrossingEquipment>
+        <StaircaseEquipment id="ALM:StaircaseEquipment:w167_n73_n839:LOC" version="1">
+          <DirectionOfUse>both</DirectionOfUse>
+          <HandrailType>none</HandrailType>
+          <TopEnd>
+            <TexturedSurface>false</TexturedSurface>
+          </TopEnd>
+        </StaircaseEquipment>
+        <StaircaseEquipment id="ALM:StaircaseEquipment:w170_n118_n117:LOC" version="1">
+          <DirectionOfUse>both</DirectionOfUse>
+          <NumberOfSteps>8</NumberOfSteps>
+          <StepColourContrast>false</StepColourContrast>
+          <HandrailType>none</HandrailType>
+          <TopEnd>
+            <TexturedSurface>false</TexturedSurface>
+          </TopEnd>
+          <BottomEnd>
+            <TexturedSurface>false</TexturedSurface>
+          </BottomEnd>
+        </StaircaseEquipment>
+        <StaircaseEquipment id="ALM:StaircaseEquipment:w174_n74_n823:LOC" version="1">
+          <DirectionOfUse>both</DirectionOfUse>
+          <HandrailType>none</HandrailType>
+          <TopEnd>
+            <TexturedSurface>false</TexturedSurface>
+          </TopEnd>
+          <BottomEnd>
+            <TexturedSurface>false</TexturedSurface>
+          </BottomEnd>
+        </StaircaseEquipment>
+        <CrossingEquipment id="ALM:CrossingEquipment:w176_n824_n858:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+          </keyList>
+          <DirectionOfUse>both</DirectionOfUse>
+          <CrossingType>roadCrossing</CrossingType>
+          <ZebraCrossing>true</ZebraCrossing>
+          <AcousticCrossingAids>false</AcousticCrossingAids>
+          <TactileWarningStrip>noTactileStrip</TactileWarningStrip>
+          <VisualGuidanceBands>false</VisualGuidanceBands>
+          <DroppedKerb>false</DroppedKerb>
+          <MarkingStatus>good</MarkingStatus>
+        </CrossingEquipment>
+        <CrossingEquipment id="ALM:CrossingEquipment:w179_n120_n878:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+          </keyList>
+          <Width>1.50</Width>
+          <DirectionOfUse>both</DirectionOfUse>
+          <CrossingType>roadCrossing</CrossingType>
+          <ZebraCrossing>true</ZebraCrossing>
+          <PedestrianLights>false</PedestrianLights>
+          <AcousticCrossingAids>false</AcousticCrossingAids>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <VisualGuidanceBands>false</VisualGuidanceBands>
+          <DroppedKerb>true</DroppedKerb>
+          <MarkingStatus>good</MarkingStatus>
+        </CrossingEquipment>
+        <CrossingEquipment id="ALM:CrossingEquipment:w184_n817_n800:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+          </keyList>
+          <DirectionOfUse>both</DirectionOfUse>
+          <CrossingType>roadCrossing</CrossingType>
+          <ZebraCrossing>true</ZebraCrossing>
+          <AcousticCrossingAids>false</AcousticCrossingAids>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <VisualGuidanceBands>false</VisualGuidanceBands>
+          <DroppedKerb>true</DroppedKerb>
+          <MarkingStatus>good</MarkingStatus>
+        </CrossingEquipment>
+        <CrossingEquipment id="ALM:CrossingEquipment:w185_n870_n815:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AcousticCrossingAids</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+          </keyList>
+          <DirectionOfUse>both</DirectionOfUse>
+          <CrossingType>roadCrossing</CrossingType>
+          <ZebraCrossing>true</ZebraCrossing>
+          <AcousticCrossingAids>false</AcousticCrossingAids>
+          <TactileWarningStrip>tactileStripAtBothEnds</TactileWarningStrip>
+          <VisualGuidanceBands>false</VisualGuidanceBands>
+          <DroppedKerb>true</DroppedKerb>
+          <MarkingStatus>good</MarkingStatus>
+        </CrossingEquipment>
+        <PathJunction id="ALM:PathJunction:n26:LOC" version="2">
+          <Location id="n26">
+            <Longitude>2.6499866</Longitude>
+            <Latitude>48.8388332</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n73:LOC" version="2">
+          <Location id="n73">
+            <Longitude>2.6556716</Longitude>
+            <Latitude>48.8362768</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n74:LOC" version="2">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n74">
+            <Longitude>2.6556605</Longitude>
+            <Latitude>48.8365207</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n80:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Obstacle</Key>
+              <Value>CycleBarrier</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ObstacleType</Key>
+              <Value>Pass</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n80">
+            <Longitude>2.649993</Longitude>
+            <Latitude>48.8387712</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n117:LOC" version="3">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n117">
+            <Longitude>2.6545379</Longitude>
+            <Latitude>48.835577</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n118:LOC" version="3">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n118">
+            <Longitude>2.6545363</Longitude>
+            <Latitude>48.835648</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n120:LOC" version="3">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n120">
+            <Longitude>2.6558197</Longitude>
+            <Latitude>48.8362245</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n121:LOC" version="3">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n121">
+            <Longitude>2.654666</Longitude>
+            <Latitude>48.8355572</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n122:LOC" version="3">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n122">
+            <Longitude>2.6547723</Longitude>
+            <Latitude>48.83548</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n800:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n800">
+            <Longitude>2.65667237274</Longitude>
+            <Latitude>48.83623838995</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n801:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n801">
+            <Longitude>2.65311240882</Longitude>
+            <Latitude>48.83501358425</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n813:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n813">
+            <Longitude>2.65592711678</Longitude>
+            <Latitude>48.83663726109</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n815:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n815">
+            <Longitude>2.65378832549</Longitude>
+            <Latitude>48.83498886711</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n817:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n817">
+            <Longitude>2.65672132306</Longitude>
+            <Latitude>48.83628826434</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n823:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n823">
+            <Longitude>2.65587374501</Longitude>
+            <Latitude>48.83661752235</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n824:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Raised</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbHeight</Key>
+              <Value>0.2</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n824">
+            <Longitude>2.65399485558</Longitude>
+            <Latitude>48.83523074141</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n833:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n833">
+            <Longitude>2.65614464812</Longitude>
+            <Latitude>48.83671771169</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n839:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n839">
+            <Longitude>2.65574298732</Longitude>
+            <Latitude>48.83622691442</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n855:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n855">
+            <Longitude>2.65303194255</Longitude>
+            <Latitude>48.83494649485</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n858:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Raised</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbHeight</Key>
+              <Value>0.2</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n858">
+            <Longitude>2.65406727523</Longitude>
+            <Latitude>48.83527664443</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n870:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n870">
+            <Longitude>2.65373736352</Longitude>
+            <Latitude>48.83503653586</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n878:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbDesign</Key>
+              <Value>Lowered</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n878">
+            <Longitude>2.65595622228</Longitude>
+            <Latitude>48.83613367478</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n37:LOC" version="1">
+          <Location id="n37">
+            <Longitude>2.6516844</Longitude>
+            <Latitude>48.8389974</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n832:LOC" version="1">
+          <Location id="n832">
+            <Longitude>2.65464775665</Longitude>
+            <Latitude>48.83557574592</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n825:LOC" version="1">
+          <Location id="n825">
+            <Longitude>2.65303730696</Longitude>
+            <Latitude>48.83456690843</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n843:LOC" version="1">
+          <Location id="n843">
+            <Longitude>2.6530185315</Longitude>
+            <Latitude>48.83439565222</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n882:LOC" version="1">
+          <Location id="n882">
+            <Longitude>2.65630625121</Longitude>
+            <Latitude>48.83611613128</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n840:LOC" version="1">
+          <Location id="n840">
+            <Longitude>2.65371590585</Longitude>
+            <Latitude>48.83508420457</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n868:LOC" version="1">
+          <Location id="n868">
+            <Longitude>2.6545608037</Longitude>
+            <Latitude>48.83556530151</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n114:LOC" version="1">
+          <Location id="n114">
+            <Longitude>2.6549161</Longitude>
+            <Latitude>48.8358105</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n880:LOC" version="1">
+          <Location id="n880">
+            <Longitude>2.65385538071</Longitude>
+            <Latitude>48.83498357058</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n856:LOC" version="1">
+          <Location id="n856">
+            <Longitude>2.65407010436</Longitude>
+            <Latitude>48.83509934589</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n798:LOC" version="1">
+          <Location id="n798">
+            <Longitude>2.65381425727</Longitude>
+            <Latitude>48.83496262563</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n811:LOC" version="1">
+          <Location id="n811">
+            <Longitude>2.65485015199</Longitude>
+            <Latitude>48.8355229844</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n859:LOC" version="1">
+          <Location id="n859">
+            <Longitude>2.65529036254</Longitude>
+            <Latitude>48.83414141512</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n827:LOC" version="1">
+          <Location id="n827">
+            <Longitude>2.65333090281</Longitude>
+            <Latitude>48.83471644337</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n831:LOC" version="1">
+          <Location id="n831">
+            <Longitude>2.65346646041</Longitude>
+            <Latitude>48.83514423176</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n805:LOC" version="1">
+          <Location id="n805">
+            <Longitude>2.65357643098</Longitude>
+            <Latitude>48.83505065993</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n877:LOC" version="1">
+          <Location id="n877">
+            <Longitude>2.65462481473</Longitude>
+            <Latitude>48.83540029175</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n867:LOC" version="1">
+          <Location id="n867">
+            <Longitude>2.6541842</Longitude>
+            <Latitude>48.835854</Latitude>
+          </Location>
+        </PathJunction>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_onstreetbus_example/parking.xml
+++ b/exemples/AccesLibreMobilites/ALM_onstreetbus_example/parking.xml
@@ -1,0 +1,110 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_PARKING:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_PARKING:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <ParkingBay id="ALM:ParkingBay:n794:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>FlooringMaterial</Key>
+              <Value>Asphalt</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Slope</Key>
+              <Value>0</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Tilt</Key>
+              <Value>0</Value>
+            </KeyValue>
+          </keyList>
+          <Centroid>
+            <Location id="n794">
+              <Longitude>2.65369981259</Longitude>
+              <Latitude>48.83513716974</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:5:" version="any">
+            <validityConditions>
+              <ValidityCondition id="ALM:ValidityCondition:5:" version="any">
+                <Description>Marquage au sol et signalétiques non conformes</Description>
+              </ValidityCondition>
+            </validityConditions>
+            <MobilityImpairedAccess>partial</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <VisualSignsAvailable>partial</VisualSignsAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>disabledPublicOnly</PublicUse>
+          <ParkingVehicleType>car</ParkingVehicleType>
+          <BayGeometry>orthogonal</BayGeometry>
+          <ParkingVisibility>demarcated</ParkingVisibility>
+          <Width>3.40</Width>
+          <RechargingAvailable>false</RechargingAvailable>
+        </ParkingBay>
+        <ParkingBay id="ALM:ParkingBay:n808:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>FlooringMaterial</Key>
+              <Value>Asphalt</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Slope</Key>
+              <Value>0</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Tilt</Key>
+              <Value>0</Value>
+            </KeyValue>
+          </keyList>
+          <Centroid>
+            <Location id="n808">
+              <Longitude>2.65394389361</Longitude>
+              <Latitude>48.83525369292</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:6:" version="any">
+            <validityConditions>
+              <ValidityCondition id="ALM:ValidityCondition:6:" version="any">
+                <Description>Marquage au sol présent mais signalétique non conforme</Description>
+              </ValidityCondition>
+            </validityConditions>
+            <MobilityImpairedAccess>partial</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <VisualSignsAvailable>partial</VisualSignsAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>disabledPublicOnly</PublicUse>
+          <ParkingVehicleType>car</ParkingVehicleType>
+          <BayGeometry>orthogonal</BayGeometry>
+          <ParkingVisibility>demarcated</ParkingVisibility>
+          <Width>3.00</Width>
+          <RechargingAvailable>false</RechargingAvailable>
+        </ParkingBay>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_onstreetbus_example/poi.xml
+++ b/exemples/AccesLibreMobilites/ALM_onstreetbus_example/poi.xml
@@ -1,0 +1,433 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_COMMUN:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_COMMUN:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <PointOfInterest id="ALM:PointOfInterest:w147:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>PointOfInterest</Key>
+              <Value>Healthcare</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Centre de test covid de Seine-et-Marne</Name>
+          <gml:Polygon gml:id="w147">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.65374970755 48.8356534071</gml:pos>
+                <gml:pos>2.65388261488 48.83559292887</gml:pos>
+                <gml:pos>2.65407907107 48.83577997951</gml:pos>
+                <gml:pos>2.654018469 48.83580755582</gml:pos>
+                <gml:pos>2.65394616375 48.83584045752</gml:pos>
+                <gml:pos>2.65374970755 48.8356534071</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:48:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <facilities>
+            <SiteFacilitySet id="ALM:SiteFacilitySet:48:" version="any">
+              <MobilityFacilityList>suitableForWheelchairs</MobilityFacilityList>
+              <SanitaryFacilityList>toilet wheelchairAccessToilet babyChange wheelchairBabyChange</SanitaryFacilityList>
+            </SiteFacilitySet>
+          </facilities>
+          <entrances>
+            <EntranceRef ref="ALM:Entrance:n884:LOC" version="1"/>
+          </entrances>
+        </PointOfInterest>
+        <PointOfInterest id="ALM:PointOfInterest:w148:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>PointOfInterest</Key>
+              <Value>Religion</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Religion</Key>
+              <Value>Muslim</Value>
+            </KeyValue>
+          </keyList>
+          <gml:Polygon gml:id="w148">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.65476346535 48.83514928022</gml:pos>
+                <gml:pos>2.65498935442 48.83505649979</gml:pos>
+                <gml:pos>2.65505783581 48.83512873762</gml:pos>
+                <gml:pos>2.65483194675 48.83522151792</gml:pos>
+                <gml:pos>2.6547919455 48.83517932255</gml:pos>
+                <gml:pos>2.65476346535 48.83514928022</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:49:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>unknown</WheelchairAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>false</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <facilities>
+            <SiteFacilitySet id="ALM:SiteFacilitySet:49:" version="any">
+              <MobilityFacilityList>unknown</MobilityFacilityList>
+              <SanitaryFacilityList>none</SanitaryFacilityList>
+            </SiteFacilitySet>
+          </facilities>
+          <entrances>
+            <EntranceRef ref="ALM:Entrance:n816:LOC" version="1"/>
+          </entrances>
+        </PointOfInterest>
+        <PointOfInterest id="ALM:PointOfInterest:w166:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Education</Key>
+              <Value>HighSchool</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>PointOfInterest</Key>
+              <Value>Education</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Lycée Jean Moulin</Name>
+          <gml:Polygon gml:id="w166">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.65660464495 48.83612584269</gml:pos>
+                <gml:pos>2.65646199243 48.83602246212</gml:pos>
+                <gml:pos>2.65633910626 48.83593340609</gml:pos>
+                <gml:pos>2.65693187445 48.83533490589</gml:pos>
+                <gml:pos>2.65729397267 48.8350435979</gml:pos>
+                <gml:pos>2.65760242671 48.83476817787</gml:pos>
+                <gml:pos>2.65916347235 48.83527134793</gml:pos>
+                <gml:pos>2.65869676799 48.83576215455</gml:pos>
+                <gml:pos>2.65797525376 48.83601285248</gml:pos>
+                <gml:pos>2.65714645118 48.83604816195</gml:pos>
+                <gml:pos>2.65660464495 48.83612584269</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:50:" version="any">
+            <validityConditions>
+              <ValidityCondition id="ALM:ValidityCondition:50:" version="any">
+                <Description>forte pente entre l'entrée et les bâtiments où sont dispensés les cours</Description>
+              </ValidityCondition>
+            </validityConditions>
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>partial</WheelchairAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>false</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <facilities>
+            <SiteFacilitySet id="ALM:SiteFacilitySet:50:" version="any">
+              <MobilityFacilityList>unknown</MobilityFacilityList>
+              <SanitaryFacilityList>toilet wheelchairAccessToilet</SanitaryFacilityList>
+            </SiteFacilitySet>
+          </facilities>
+          <entrances>
+            <EntranceRef ref="ALM:Entrance:n847:LOC" version="1"/>
+          </entrances>
+        </PointOfInterest>
+        <PointOfInterest id="ALM:PointOfInterest:w172:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Government</Key>
+              <Value>SocialWelfare</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>PointOfInterest</Key>
+              <Value>Government</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Caf de Seine-et-Marne</Name>
+          <gml:Polygon gml:id="w172">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.65323621152 48.83519334604</gml:pos>
+                <gml:pos>2.6533680739 48.83512718229</gml:pos>
+                <gml:pos>2.65342391902 48.83517540352</gml:pos>
+                <gml:pos>2.65351700129 48.83525577824</gml:pos>
+                <gml:pos>2.65338513891 48.83532194182</gml:pos>
+                <gml:pos>2.65323621152 48.83519334604</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:51:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <facilities>
+            <SiteFacilitySet id="ALM:SiteFacilitySet:51:" version="any">
+              <MobilityFacilityList>suitableForWheelchairs</MobilityFacilityList>
+              <SanitaryFacilityList>toilet wheelchairAccessToilet babyChange wheelchairBabyChange</SanitaryFacilityList>
+            </SiteFacilitySet>
+          </facilities>
+          <entrances>
+            <EntranceRef ref="ALM:Entrance:n846:LOC" version="1"/>
+          </entrances>
+        </PointOfInterest>
+        <PointOfInterest id="ALM:PointOfInterest:w173:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>PointOfInterest</Key>
+              <Value>Sport</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Sport</Key>
+              <Value>FitnessCenter</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Gymnase de la Fraternité</Name>
+          <gml:Polygon gml:id="w173">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.65468224845 48.83508808579</gml:pos>
+                <gml:pos>2.65448936481 48.83490667093</gml:pos>
+                <gml:pos>2.65443554904 48.8348560549</gml:pos>
+                <gml:pos>2.65492404966 48.83463102262</gml:pos>
+                <gml:pos>2.65511875959 48.8348141562</gml:pos>
+                <gml:pos>2.65485260646 48.83493676176</gml:pos>
+                <gml:pos>2.65490459593 48.83498565999</gml:pos>
+                <gml:pos>2.65468224845 48.83508808579</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:52:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>false</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <facilities>
+            <SiteFacilitySet id="ALM:SiteFacilitySet:52:" version="any">
+              <MobilityFacilityList>suitableForWheelchairs</MobilityFacilityList>
+              <SanitaryFacilityList>toilet wheelchairAccessToilet shower washingAndChangeFacilities</SanitaryFacilityList>
+            </SiteFacilitySet>
+          </facilities>
+          <entrances>
+            <EntranceRef ref="ALM:Entrance:n841:LOC" version="1"/>
+          </entrances>
+        </PointOfInterest>
+        <PointOfInterestEntrance id="ALM:Entrance:n816:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Door</Key>
+              <Value>Hinged</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>EntrancePassage</Key>
+              <Value>Door</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Centroid>
+            <Location id="n816">
+              <Longitude>2.6547919455</Longitude>
+              <Latitude>48.83517932255</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:0:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>unknown</StepFreeAccess>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="ALM:PointOfInterest:w148:LOC" version="1"/>
+          <placeEquipments>
+            <EntranceEquipmentRef ref="ALM:EntranceEquipment:n816:LOC"/>
+          </placeEquipments>
+          <EntranceType>door</EntranceType>
+          <Width>1.00</Width>
+        </PointOfInterestEntrance>
+        <PointOfInterestEntrance id="ALM:Entrance:n841:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Door</Key>
+              <Value>Hinged</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>EntrancePassage</Key>
+              <Value>Door</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Centroid>
+            <Location id="n841">
+              <Longitude>2.65448936481</Longitude>
+              <Latitude>48.83490667093</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:1:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>unknown</StepFreeAccess>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="ALM:PointOfInterest:w173:LOC" version="1"/>
+          <placeEquipments>
+            <EntranceEquipmentRef ref="ALM:EntranceEquipment:n841:LOC"/>
+          </placeEquipments>
+          <EntranceType>door</EntranceType>
+          <Width>1.00</Width>
+        </PointOfInterestEntrance>
+        <PointOfInterestEntrance id="ALM:Entrance:n846:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AutomaticDoor</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Door</Key>
+              <Value>Sliding</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>EntrancePassage</Key>
+              <Value>Door</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Centroid>
+            <Location id="n846">
+              <Longitude>2.65342391902</Longitude>
+              <Latitude>48.83517540352</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:2:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>unknown</StepFreeAccess>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="ALM:PointOfInterest:w172:LOC" version="1"/>
+          <placeEquipments>
+            <EntranceEquipmentRef ref="ALM:EntranceEquipment:n846:LOC"/>
+          </placeEquipments>
+          <EntranceType>automaticDoor</EntranceType>
+          <Width>1.00</Width>
+        </PointOfInterestEntrance>
+        <PointOfInterestEntrance id="ALM:Entrance:n847:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>EntrancePassage</Key>
+              <Value>Gate</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Centroid>
+            <Location id="n847">
+              <Longitude>2.65646199243</Longitude>
+              <Latitude>48.83602246212</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:3:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>unknown</WheelchairAccess>
+                <StepFreeAccess>unknown</StepFreeAccess>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="ALM:PointOfInterest:w166:LOC" version="1"/>
+          <placeEquipments>
+            <EntranceEquipmentRef ref="ALM:EntranceEquipment:n847:LOC"/>
+          </placeEquipments>
+          <EntranceType>gate</EntranceType>
+          <Width>2.00</Width>
+        </PointOfInterestEntrance>
+        <PointOfInterestEntrance id="ALM:Entrance:n884:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Door</Key>
+              <Value>Hinged</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>EntrancePassage</Key>
+              <Value>Door</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+          </keyList>
+          <Centroid>
+            <Location id="n884">
+              <Longitude>2.654018469</Longitude>
+              <Latitude>48.83580755582</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:4:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>unknown</StepFreeAccess>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="ALM:PointOfInterest:w147:LOC" version="1"/>
+          <placeEquipments>
+            <EntranceEquipmentRef ref="ALM:EntranceEquipment:n884:LOC"/>
+          </placeEquipments>
+          <EntranceType>door</EntranceType>
+          <Width>1.00</Width>
+        </PointOfInterestEntrance>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_onstreetbus_example/resource.xml
+++ b/exemples/AccesLibreMobilites/ALM_onstreetbus_example/resource.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_COMMUN:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_COMMUN:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <DataSource id="FR:ALM:DataSource:ALMUser" version="any">
+          <Name>Une instance AccèsLibre Mobilités</Name>
+          <Description>Accèslibre Mobilités est une suite logicielle qui permet aux collectivités de collecter, créer et publier les données d'accessibilité des transports et de la voirie.</Description>
+        </DataSource>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_onstreetbus_example/stop.xml
+++ b/exemples/AccesLibreMobilites/ALM_onstreetbus_example/stop.xml
@@ -1,0 +1,167 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_ARRET:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_ARRET:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <Quay id="ALM:Quay:n803:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>RubbishDisposal</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Seating</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Shelter</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Lycée Jean Moulin</Name>
+          <Centroid>
+            <Location id="n803">
+              <Longitude>2.65543949937</Longitude>
+              <Latitude>48.83601309759</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:8:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="ALM:StopPlace:g_n803_bus:LOC" version="any"/>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:80" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n803_8_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:ShelterEquipment:n803:LOC" version="1"/>
+                  <Location id="n803">
+                    <Longitude>2.65543949937</Longitude>
+                    <Latitude>48.83601309759</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:81" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n803_8_1:LOC" version="any">
+                  <EquipmentRef ref="ALM:RubbishDisposalEquipment:n803:LOC" version="1"/>
+                  <Location id="n803">
+                    <Longitude>2.65543949937</Longitude>
+                    <Latitude>48.83601309759</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:82" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n803_8_2:LOC" version="any">
+                  <EquipmentRef ref="ALM:SeatingEquipment:n803:LOC" version="1"/>
+                  <Location id="n803">
+                    <Longitude>2.65543949937</Longitude>
+                    <Latitude>48.83601309759</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+          <TransportMode>bus</TransportMode>
+        </Quay>
+        <Quay id="ALM:Quay:n822:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>RubbishDisposal</Key>
+              <Value>No</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Seating</Key>
+              <Value>No</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Shelter</Key>
+              <Value>No</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Worn</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Lycée Jean Moulin</Name>
+          <Centroid>
+            <Location id="n822">
+              <Longitude>2.65565746015</Longitude>
+              <Latitude>48.83596872112</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:9:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="ALM:StopPlace:g_n803_bus:LOC" version="any"/>
+          <TransportMode>bus</TransportMode>
+        </Quay>
+        <StopPlace id="ALM:StopPlace:g_n803_bus:LOC" version="any">
+          <Name>Lycée Jean Moulin</Name>
+          <placeTypes>
+            <TypeOfPlaceRef ref="monomodalStopPlace"/>
+          </placeTypes>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:47:" version="any">
+            <validityConditions>
+              <ValidityCondition id="ALM:ValidityCondition:47:" version="any">
+                <Description>Présence inconnue d'un cheminement pratiquable en fauteuil roulant entre les quais</Description>
+              </ValidityCondition>
+            </validityConditions>
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>partial</WheelchairAccess>
+                <StepFreeAccess>unknown</StepFreeAccess>
+                <EscalatorFreeAccess>unknown</EscalatorFreeAccess>
+                <LiftFreeAccess>unknown</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <facilities>
+            <SiteFacilitySet id="ALM:SiteFacilitySet:47:" version="any">
+              <MobilityFacilityList>tactilePlatformEdges</MobilityFacilityList>
+            </SiteFacilitySet>
+          </facilities>
+          <TransportMode>bus</TransportMode>
+          <StopPlaceType>onstreetBus</StopPlaceType>
+          <quays>
+            <QuayRef version="1" ref="ALM:Quay:n822:LOC"/>
+            <QuayRef version="1" ref="ALM:Quay:n803:LOC"/>
+          </quays>
+        </StopPlace>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_railstation_example/accessibility.xml
+++ b/exemples/AccesLibreMobilites/ALM_railstation_example/accessibility.xml
@@ -1,0 +1,1520 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_ACCESSIBILITY:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_ACCESSIBILITY:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <SitePathLink id="ALM:SitePathLink:n-144056_level-1_level0:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>-1;0;1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualDisplays</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>0.00</Distance>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144056:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144056:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:4:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>false</LiftFreeAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Lighting>wellLit</Lighting>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <MinimumWidth>1.00</MinimumWidth>
+          <AccessFeatureType>lift</AccessFeatureType>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+          <placeEquipments>
+            <LiftEquipmentRef ref="ALM:LiftEquipment:n-144056:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:n-144056_level0_level1:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>-1;0;1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualDisplays</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>0.00</Distance>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144056:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144056:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:5:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>false</LiftFreeAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Lighting>wellLit</Lighting>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <MinimumWidth>1.00</MinimumWidth>
+          <AccessFeatureType>lift</AccessFeatureType>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+          <placeEquipments>
+            <LiftEquipmentRef ref="ALM:LiftEquipment:n-144056:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:n-144057_level-1_level1:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>1;-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualDisplays</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>0.00</Distance>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144057:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144057:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:6:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>false</LiftFreeAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Lighting>wellLit</Lighting>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <MinimumWidth>1.00</MinimumWidth>
+          <AccessFeatureType>lift</AccessFeatureType>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+          <placeEquipments>
+            <LiftEquipmentRef ref="ALM:LiftEquipment:n-144057:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:n-144058_level-1_level0:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0;-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualDisplays</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>0.00</Distance>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144058:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144058:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:7:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>false</LiftFreeAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Lighting>wellLit</Lighting>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <MinimumWidth>1.00</MinimumWidth>
+          <AccessFeatureType>lift</AccessFeatureType>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+          <placeEquipments>
+            <LiftEquipmentRef ref="ALM:LiftEquipment:n-144058:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116870_n-144060_n-144065:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>12</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>13.89</Distance>
+          <gml:LineString gml:id="w-116870_n-144060_n-144065">
+            <gml:pos>2.65408764898 48.83979159193</gml:pos>
+            <gml:pos>2.65410205923 48.83973940846</gml:pos>
+            <gml:pos>2.65412500627 48.83974215344</gml:pos>
+            <gml:pos>2.65415294941 48.83974549605</gml:pos>
+            <gml:pos>2.65420946112 48.83975225609</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:Entrance:n-144060:LOC" versionRef="any"/>
+            <EntranceRef ref="ALM:Entrance:n-144060:LOC" versionRef="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144065:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:8:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>12.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>hall</AccessFeatureType>
+          <FlooringType>ceramicTiles</FlooringType>
+          <TactileWarningStrip>tactileStripAtEnd</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:80" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144081_8_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketValidatorEquipment:n-144081:LOC" version="any"/>
+                  <Location id="n-144081">
+                    <Longitude>2.65412500627</Longitude>
+                    <Latitude>48.83974215344</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116871_n-144062_n-144066:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>4</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>32.60</Distance>
+          <gml:LineString gml:id="w-116871_n-144062_n-144066">
+            <gml:pos>2.65438070536 48.83977224757</gml:pos>
+            <gml:pos>2.6543876969 48.8397421965</gml:pos>
+            <gml:pos>2.65441209744 48.83963731784</gml:pos>
+            <gml:pos>2.65443788414 48.83952650301</gml:pos>
+            <gml:pos>2.65444813659 48.83948241357</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144062:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144066:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:9:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>4.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>hall</AccessFeatureType>
+          <FlooringType>ceramicTiles</FlooringType>
+          <TactileWarningStrip>noTactileStrip</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116872_n-144063_n-144059:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>12</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>21.91</Distance>
+          <gml:LineString gml:id="w-116872_n-144063_n-144059">
+            <gml:pos>2.65445905295 48.83944175887</gml:pos>
+            <gml:pos>2.6545155757 48.83941050547</gml:pos>
+            <gml:pos>2.65457973384 48.83937503016</gml:pos>
+            <gml:pos>2.65462972685 48.83934738723</gml:pos>
+            <gml:pos>2.6545805386 48.83930885125</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144063:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:Entrance:n-144059:LOC" versionRef="any"/>
+            <EntranceRef ref="ALM:Entrance:n-144059:LOC" versionRef="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:10:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <AllAreasWheelchairAccessible>true</AllAreasWheelchairAccessible>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>12.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>hall</AccessFeatureType>
+          <FlooringType>ceramicTiles</FlooringType>
+          <TactileWarningStrip>tactileStripAtBeginning</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:100" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144078_10_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketValidatorEquipment:n-144078:LOC" version="any"/>
+                  <Location id="n-144078">
+                    <Longitude>2.65457973384</Longitude>
+                    <Latitude>48.83937503016</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116873_n-144065_n-144062:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0;-1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>12.73</Distance>
+          <gml:LineString gml:id="w-116873_n-144065_n-144062">
+            <gml:pos>2.65420946112 48.83975225609</gml:pos>
+            <gml:pos>2.65438070536 48.83977224757</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144065:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144062:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:11:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Transition>down</Transition>
+          <AccessFeatureType>stairs</AccessFeatureType>
+          <TactileWarningStrip>tactileStripAtBeginning</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+          <placeEquipments>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116873_n-144065_n-144062:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116874_n-144066_n-144063:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0;-1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>4.59</Distance>
+          <gml:LineString gml:id="w-116874_n-144066_n-144063">
+            <gml:pos>2.65444813659 48.83948241357</gml:pos>
+            <gml:pos>2.65445905295 48.83944175887</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144066:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144063:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:12:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Transition>up</Transition>
+          <AccessFeatureType>stairs</AccessFeatureType>
+          <TactileWarningStrip>tactileStripAtEnd</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+          <placeEquipments>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116874_n-144066_n-144063:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116875_n-144084_n-144056:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>4</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>7.20</Distance>
+          <gml:LineString gml:id="w-116875_n-144084_n-144056">
+            <gml:pos>2.65443788414 48.83952650301</gml:pos>
+            <gml:pos>2.65450626661 48.83953317407</gml:pos>
+            <gml:pos>2.65451054706 48.83951416699</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144084:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144056:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:13:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>4.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>hall</AccessFeatureType>
+          <FlooringType>ceramicTiles</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116876_n-144068_n-144069:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0;1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>5.42</Distance>
+          <gml:LineString gml:id="w-116876_n-144068_n-144069">
+            <gml:pos>2.65458225936 48.83947306197</gml:pos>
+            <gml:pos>2.6545744625 48.83952155317</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144068:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144069:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:14:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Transition>up</Transition>
+          <AccessFeatureType>stairs</AccessFeatureType>
+          <TactileWarningStrip>tactileStripAtEnd</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+          <placeEquipments>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116876_n-144068_n-144069:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116877_n-144070_n-144082:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>3</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>2.25</Distance>
+          <gml:LineString gml:id="w-116877_n-144070_n-144082">
+            <gml:pos>2.65441209744 48.83963731784</gml:pos>
+            <gml:pos>2.654442481 48.83964037998</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144070:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144082:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:15:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>3.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>hall</AccessFeatureType>
+          <FlooringType>ceramicTiles</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116878_n-144062_n-144072:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>4</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>3.26</Distance>
+          <gml:LineString gml:id="w-116878_n-144062_n-144072">
+            <gml:pos>2.65438070536 48.83977224757</gml:pos>
+            <gml:pos>2.65437572926 48.83980141637</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144062:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144072:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:16:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>4.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>hall</AccessFeatureType>
+          <FlooringType>ceramicTiles</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116879_n-144073_n-144058:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>12</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>14.74</Distance>
+          <gml:LineString gml:id="w-116879_n-144073_n-144058">
+            <gml:pos>2.65419334039 48.83977934872</gml:pos>
+            <gml:pos>2.65415294941 48.83974549605</gml:pos>
+            <gml:pos>2.65421077475 48.83972374044</gml:pos>
+            <gml:pos>2.65427926781 48.83973126874</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144073:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144058:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:17:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>12.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>hall</AccessFeatureType>
+          <FlooringType>ceramicTiles</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116880_n-144072_n-144073:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0;-1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>13.57</Distance>
+          <gml:LineString gml:id="w-116880_n-144072_n-144073">
+            <gml:pos>2.65437572926 48.83980141637</gml:pos>
+            <gml:pos>2.65419334039 48.83977934872</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144072:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144073:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:18:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>false</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <AccessFeatureType>escalator</AccessFeatureType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+          <placeEquipments>
+            <EscalatorEquipmentRef ref="ALM:EscalatorEquipment:w-116880_n-144072_n-144073:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116881_n-144080_n-144058:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>4</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>8.03</Distance>
+          <gml:LineString gml:id="w-116881_n-144080_n-144058">
+            <gml:pos>2.6543876969 48.8397421965</gml:pos>
+            <gml:pos>2.65427926781 48.83973126874</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144080:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144058:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:19:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>4.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>hall</AccessFeatureType>
+          <FlooringType>ceramicTiles</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116882_n-144057_n-144070:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>4</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>3.86</Distance>
+          <gml:LineString gml:id="w-116882_n-144057_n-144070">
+            <gml:pos>2.65436001859 48.83963206919</gml:pos>
+            <gml:pos>2.65441209744 48.83963731784</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144057:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144070:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:20:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>4.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>hall</AccessFeatureType>
+          <FlooringType>ceramicTiles</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116887_n-144056_n-144068:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Flooring</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>12</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>20.03</Distance>
+          <gml:LineString gml:id="w-116887_n-144056_n-144068">
+            <gml:pos>2.65451054706 48.83951416699</gml:pos>
+            <gml:pos>2.6545155757 48.83941050547</gml:pos>
+            <gml:pos>2.65458225936 48.83947306197</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144056:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144068:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:21:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>false</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <NumberOfSteps>0</NumberOfSteps>
+          <MinimumWidth>12.00</MinimumWidth>
+          <Gradient>0</Gradient>
+          <GradientType>level</GradientType>
+          <TiltAngle>0</TiltAngle>
+          <TiltType>nearlyFlat</TiltType>
+          <AccessFeatureType>hall</AccessFeatureType>
+          <FlooringType>ceramicTiles</FlooringType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w-116981_n-144082_n-144071:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>1;-1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>7.55</Distance>
+          <gml:LineString gml:id="w-116981_n-144082_n-144071">
+            <gml:pos>2.654442481 48.83964037998</gml:pos>
+            <gml:pos>2.65454446158 48.83965065787</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n-144082:LOC" version="any"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n-144071:LOC" version="any"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:22:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <StepFreeAccess>false</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Transition>up</Transition>
+          <AccessFeatureType>stairs</AccessFeatureType>
+          <TactileWarningStrip>tactileStripAtEnd</TactileWarningStrip>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" versionRef="any"/>
+          <placeEquipments>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116981_n-144082_n-144071:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <EntranceEquipment id="ALM:EntranceEquipment:n-144059:LOC" version="any">
+          <Width>2.00</Width>
+          <Door>true</Door>
+          <DropKerbOutside>true</DropKerbOutside>
+          <AutomaticDoor>true</AutomaticDoor>
+          <WheelchairPassable>true</WheelchairPassable>
+          <NecessaryForceToOpen>noForce</NecessaryForceToOpen>
+        </EntranceEquipment>
+        <EntranceEquipment id="ALM:EntranceEquipment:n-144060:LOC" version="any">
+          <Width>2.00</Width>
+          <Door>true</Door>
+          <DropKerbOutside>true</DropKerbOutside>
+          <AutomaticDoor>true</AutomaticDoor>
+          <WheelchairPassable>true</WheelchairPassable>
+          <NecessaryForceToOpen>noForce</NecessaryForceToOpen>
+        </EntranceEquipment>
+        <TicketingEquipment id="ALM:TicketingEquipment:n-144075:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Amenity</Key>
+              <Value>TicketOffice</Value>
+            </KeyValue>
+          </keyList>
+          <TicketOffice>true</TicketOffice>
+        </TicketingEquipment>
+        <AssistanceService id="ALM:AssistanceService:n-144075:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Amenity</Key>
+              <Value>TicketOffice</Value>
+            </KeyValue>
+          </keyList>
+          <AssistanceFacilityList>information</AssistanceFacilityList>
+        </AssistanceService>
+        <TicketingEquipment id="ALM:TicketingEquipment:n-144076:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Amenity</Key>
+              <Value>TicketVendingMachine</Value>
+            </KeyValue>
+          </keyList>
+          <TicketMachines>true</TicketMachines>
+        </TicketingEquipment>
+        <TicketValidatorEquipment id="ALM:TicketValidatorEquipment:n-144078:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Amenity</Key>
+              <Value>TicketValidator</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Obstacle</Key>
+              <Value>Turnstile</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ObstacleType</Key>
+              <Value>Pass</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+        </TicketValidatorEquipment>
+        <TicketValidatorEquipment id="ALM:TicketValidatorEquipment:n-144081:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Amenity</Key>
+              <Value>TicketValidator</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Obstacle</Key>
+              <Value>Turnstile</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ObstacleType</Key>
+              <Value>Pass</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+        </TicketValidatorEquipment>
+        <LiftEquipment id="ALM:LiftEquipment:n-144056:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>-1;0;1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualDisplays</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Depth>1.60</Depth>
+          <WheelchairPassable>true</WheelchairPassable>
+          <HandrailType>oneSide</HandrailType>
+          <MirrorOnOppositeSide>false</MirrorOnOppositeSide>
+          <Automatic>true</Automatic>
+          <AudioAnnouncements>true</AudioAnnouncements>
+          <ReachedFloorAnnouncement>visualAndAudio</ReachedFloorAnnouncement>
+        </LiftEquipment>
+        <LiftEquipment id="ALM:LiftEquipment:n-144057:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>1;-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualDisplays</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Depth>1.60</Depth>
+          <WheelchairPassable>true</WheelchairPassable>
+          <HandrailType>oneSide</HandrailType>
+          <MirrorOnOppositeSide>false</MirrorOnOppositeSide>
+          <Automatic>true</Automatic>
+          <AudioAnnouncements>true</AudioAnnouncements>
+          <ReachedFloorAnnouncement>visualAndAudio</ReachedFloorAnnouncement>
+        </LiftEquipment>
+        <LiftEquipment id="ALM:LiftEquipment:n-144058:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0;-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualDisplays</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Depth>1.60</Depth>
+          <WheelchairPassable>true</WheelchairPassable>
+          <HandrailType>oneSide</HandrailType>
+          <MirrorOnOppositeSide>false</MirrorOnOppositeSide>
+          <Automatic>true</Automatic>
+          <AudioAnnouncements>true</AudioAnnouncements>
+          <ReachedFloorAnnouncement>visualAndAudio</ReachedFloorAnnouncement>
+        </LiftEquipment>
+        <StaircaseEquipment id="ALM:StaircaseEquipment:w-116873_n-144065_n-144062:LOC" version="any">
+          <DirectionOfUse>both</DirectionOfUse>
+          <StepColourContrast>true</StepColourContrast>
+          <HandrailType>bothSides</HandrailType>
+          <TopEnd>
+            <ContinuingHandrail>true</ContinuingHandrail>
+            <TexturedSurface>true</TexturedSurface>
+            <VisualContrast>true</VisualContrast>
+          </TopEnd>
+          <BottomEnd>
+            <ContinuingHandrail>true</ContinuingHandrail>
+            <TexturedSurface>false</TexturedSurface>
+            <VisualContrast>true</VisualContrast>
+          </BottomEnd>
+        </StaircaseEquipment>
+        <StaircaseEquipment id="ALM:StaircaseEquipment:w-116874_n-144066_n-144063:LOC" version="any">
+          <DirectionOfUse>both</DirectionOfUse>
+          <StepColourContrast>true</StepColourContrast>
+          <HandrailType>bothSides</HandrailType>
+          <TopEnd>
+            <ContinuingHandrail>true</ContinuingHandrail>
+            <TexturedSurface>true</TexturedSurface>
+            <VisualContrast>true</VisualContrast>
+          </TopEnd>
+          <BottomEnd>
+            <ContinuingHandrail>true</ContinuingHandrail>
+            <TexturedSurface>false</TexturedSurface>
+            <VisualContrast>true</VisualContrast>
+          </BottomEnd>
+        </StaircaseEquipment>
+        <StaircaseEquipment id="ALM:StaircaseEquipment:w-116876_n-144068_n-144069:LOC" version="any">
+          <DirectionOfUse>both</DirectionOfUse>
+          <StepColourContrast>true</StepColourContrast>
+          <HandrailType>bothSides</HandrailType>
+          <TopEnd>
+            <ContinuingHandrail>true</ContinuingHandrail>
+            <TexturedSurface>true</TexturedSurface>
+            <VisualContrast>true</VisualContrast>
+          </TopEnd>
+          <BottomEnd>
+            <ContinuingHandrail>true</ContinuingHandrail>
+            <VisualContrast>true</VisualContrast>
+          </BottomEnd>
+        </StaircaseEquipment>
+        <EscalatorEquipment id="ALM:EscalatorEquipment:w-116880_n-144072_n-144073:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0;-1</Value>
+            </KeyValue>
+          </keyList>
+          <MonitoringRemoteControl>false</MonitoringRemoteControl>
+        </EscalatorEquipment>
+        <StaircaseEquipment id="ALM:StaircaseEquipment:w-116981_n-144082_n-144071:LOC" version="any">
+          <DirectionOfUse>both</DirectionOfUse>
+          <StepColourContrast>true</StepColourContrast>
+          <HandrailType>bothSides</HandrailType>
+          <TopEnd>
+            <ContinuingHandrail>true</ContinuingHandrail>
+            <TexturedSurface>true</TexturedSurface>
+            <VisualContrast>true</VisualContrast>
+          </TopEnd>
+          <BottomEnd>
+            <ContinuingHandrail>true</ContinuingHandrail>
+            <TexturedSurface>false</TexturedSurface>
+            <VisualContrast>true</VisualContrast>
+          </BottomEnd>
+        </StaircaseEquipment>
+        <PathJunction id="ALM:PathJunction:n-144062:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ContinuingHandrail</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualContrast</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n-144062">
+            <Longitude>2.65438070536</Longitude>
+            <Latitude>48.83977224757</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144063:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ContinuingHandrail</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualContrast</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n-144063">
+            <Longitude>2.65445905295</Longitude>
+            <Latitude>48.83944175887</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144065:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ContinuingHandrail</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualContrast</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n-144065">
+            <Longitude>2.65420946112</Longitude>
+            <Latitude>48.83975225609</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144066:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ContinuingHandrail</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualContrast</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n-144066">
+            <Longitude>2.65444813659</Longitude>
+            <Latitude>48.83948241357</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144068:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ContinuingHandrail</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualContrast</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n-144068">
+            <Longitude>2.65458225936</Longitude>
+            <Latitude>48.83947306197</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144069:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ContinuingHandrail</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualContrast</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n-144069">
+            <Longitude>2.6545744625</Longitude>
+            <Latitude>48.83952155317</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144071:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ContinuingHandrail</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualContrast</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n-144071">
+            <Longitude>2.65454446158</Longitude>
+            <Latitude>48.83965065787</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144082:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ContinuingHandrail</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>None</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualContrast</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n-144082">
+            <Longitude>2.654442481</Longitude>
+            <Latitude>48.83964037998</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144084:LOC" version="any">
+          <Location id="n-144084">
+            <Longitude>2.65443788414</Longitude>
+            <Latitude>48.83952650301</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144056:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AudioAnnouncements</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AutomaticDoor</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Depth</Key>
+              <Value>1.6</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Handrail</Key>
+              <Value>Left</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>-1;0;1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Lighting</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>MirrorOnOppositeSide</Key>
+              <Value>No</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>SitePathLink</Key>
+              <Value>Elevator</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualDisplays</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>WheelchairAccess</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n-144056">
+            <Longitude>2.65451054706</Longitude>
+            <Latitude>48.83951416699</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144070:LOC" version="any">
+          <Location id="n-144070">
+            <Longitude>2.65441209744</Longitude>
+            <Latitude>48.83963731784</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144072:LOC" version="any">
+          <Location id="n-144072">
+            <Longitude>2.65437572926</Longitude>
+            <Latitude>48.83980141637</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144073:LOC" version="any">
+          <Location id="n-144073">
+            <Longitude>2.65419334039</Longitude>
+            <Latitude>48.83977934872</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144058:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AudioAnnouncements</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AutomaticDoor</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Depth</Key>
+              <Value>1.6</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Handrail</Key>
+              <Value>Left</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>0;-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Lighting</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>MirrorOnOppositeSide</Key>
+              <Value>No</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>SitePathLink</Key>
+              <Value>Elevator</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualDisplays</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>WheelchairAccess</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n-144058">
+            <Longitude>2.65427926781</Longitude>
+            <Latitude>48.83973126874</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144080:LOC" version="any">
+          <Location id="n-144080">
+            <Longitude>2.6543876969</Longitude>
+            <Latitude>48.8397421965</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n-144057:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AudioAnnouncements</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AutomaticDoor</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Depth</Key>
+              <Value>1.6</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Handrail</Key>
+              <Value>Left</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>1;-1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Lighting</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>MirrorOnOppositeSide</Key>
+              <Value>No</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>SitePathLink</Key>
+              <Value>Elevator</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>VisualDisplays</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>WheelchairAccess</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Width</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n-144057">
+            <Longitude>2.65436001859</Longitude>
+            <Latitude>48.83963206919</Latitude>
+          </Location>
+        </PathJunction>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_railstation_example/poi.xml
+++ b/exemples/AccesLibreMobilites/ALM_railstation_example/poi.xml
@@ -1,0 +1,167 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_COMMUN:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_COMMUN:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <PointOfInterest id="ALM:PointOfInterest:w-116867:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>PointOfInterest</Key>
+              <Value>StopPlace</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Torcy Marne-la-Vallée</Name>
+          <gml:Polygon gml:id="w-116867">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.65366494387 48.8395984018</gml:pos>
+                <gml:pos>2.65367282562 48.83957551839</gml:pos>
+                <gml:pos>2.65368668116 48.83952343977</gml:pos>
+                <gml:pos>2.65370547749 48.83946468085</gml:pos>
+                <gml:pos>2.65371665587 48.83942267257</gml:pos>
+                <gml:pos>2.65428185195 48.83947835802</gml:pos>
+                <gml:pos>2.6545805386 48.83930885125</gml:pos>
+                <gml:pos>2.65471100539 48.83923473887</gml:pos>
+                <gml:pos>2.65505164593 48.83957192158</gml:pos>
+                <gml:pos>2.65677832285 48.83977559441</gml:pos>
+                <gml:pos>2.65676714447 48.83981760239</gml:pos>
+                <gml:pos>2.6567491377 48.83987638607</gml:pos>
+                <gml:pos>2.65673528216 48.83992846433</gml:pos>
+                <gml:pos>2.65671997994 48.8399779501</gml:pos>
+                <gml:pos>2.65443742007 48.83971667995</gml:pos>
+                <gml:pos>2.65441864461 48.8398384885</gml:pos>
+                <gml:pos>2.65408764898 48.83979159193</gml:pos>
+                <gml:pos>2.6539707157 48.83977493625</gml:pos>
+                <gml:pos>2.65394925803 48.83965312755</gml:pos>
+                <gml:pos>2.65366494387 48.8395984018</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:24:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <facilities>
+            <SiteFacilitySet id="ALM:SiteFacilitySet:24:" version="any">
+              <AccessibilityInfoFacilityList>audioInformation audioForHearingImpaired visualDisplays displaysForVisuallyImpaired</AccessibilityInfoFacilityList>
+              <MedicalFacilityList>defibrillator</MedicalFacilityList>
+              <MobilityFacilityList>suitableForWheelchairs tactilePlatformEdges</MobilityFacilityList>
+              <PassengerCommsFacilityList>publicWifi internet</PassengerCommsFacilityList>
+              <PassengerInformationEquipmentList>informationDesk realTimeDepartures</PassengerInformationEquipmentList>
+              <SanitaryFacilityList>none</SanitaryFacilityList>
+              <TicketingFacilityList>ticketMachines ticketOffice mobileTicketing</TicketingFacilityList>
+              <ParkingFacilityList>carPark cyclePark</ParkingFacilityList>
+              <Staffing>partTime</Staffing>
+            </SiteFacilitySet>
+          </facilities>
+          <entrances>
+            <EntranceRef ref="ALM:Entrance:n-144059:LOC" version="any"/>
+            <EntranceRef ref="ALM:Entrance:n-144060:LOC" version="any"/>
+          </entrances>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:240" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144076_24_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketingEquipment:n-144076:LOC" version="any"/>
+                  <Location id="n-144076">
+                    <Longitude>2.65478074417</Longitude>
+                    <Latitude>48.83936978788</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:241" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144075_24_1:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketingEquipment:n-144075:LOC" version="any"/>
+                  <Location id="n-144075">
+                    <Longitude>2.65474587545</Longitude>
+                    <Latitude>48.83944305009</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:242" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144078_24_2:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketValidatorEquipment:n-144078:LOC" version="any"/>
+                  <Location id="n-144078">
+                    <Longitude>2.65457973384</Longitude>
+                    <Latitude>48.83937503016</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:243" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144081_24_3:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketValidatorEquipment:n-144081:LOC" version="any"/>
+                  <Location id="n-144081">
+                    <Longitude>2.65412500627</Longitude>
+                    <Latitude>48.83974215344</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:244" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144075_24_4:LOC" version="any">
+                  <EquipmentRef ref="ALM:AssistanceService:n-144075:LOC" version="any"/>
+                  <Location id="n-144075">
+                    <Longitude>2.65474587545</Longitude>
+                    <Latitude>48.83944305009</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+          <placeEquipments>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116873_n-144065_n-144062:LOC"/>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116874_n-144066_n-144063:LOC"/>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116876_n-144068_n-144069:LOC"/>
+            <EscalatorEquipmentRef ref="ALM:EscalatorEquipment:w-116880_n-144072_n-144073:LOC"/>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116981_n-144082_n-144071:LOC"/>
+          </placeEquipments>
+          <pathLinks>
+            <PathLinkRef ref="ALM:SitePathLink:n-144056_level-1_level0:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:n-144056_level0_level1:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:n-144057_level-1_level1:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:n-144058_level-1_level0:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116870_n-144060_n-144065:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116871_n-144062_n-144066:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116872_n-144063_n-144059:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116873_n-144065_n-144062:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116874_n-144066_n-144063:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116875_n-144084_n-144056:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116876_n-144068_n-144069:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116877_n-144070_n-144082:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116878_n-144062_n-144072:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116879_n-144073_n-144058:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116880_n-144072_n-144073:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116881_n-144080_n-144058:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116882_n-144057_n-144070:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116887_n-144056_n-144068:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116981_n-144082_n-144071:LOC" versionRef="any"/>
+          </pathLinks>
+        </PointOfInterest>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_railstation_example/resource.xml
+++ b/exemples/AccesLibreMobilites/ALM_railstation_example/resource.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_COMMUN:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_COMMUN:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <DataSource id="FR:ALM:DataSource:ALMUser" version="any">
+          <Name>Une instance AccèsLibre Mobilités</Name>
+          <Description>Accèslibre Mobilités est une suite logicielle qui permet aux collectivités de collecter, créer et publier les données d'accessibilité des transports et de la voirie.</Description>
+        </DataSource>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_railstation_example/stop.xml
+++ b/exemples/AccesLibreMobilites/ALM_railstation_example/stop.xml
@@ -1,0 +1,336 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_ARRET:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_ARRET:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <Quay id="ALM:Quay:w-116868:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>InsideSpace</Key>
+              <Value>Quay</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+          </keyList>
+          <gml:Polygon gml:id="w-116868">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.65371665587 48.83942267257</gml:pos>
+                <gml:pos>2.65370547749 48.83946468085</gml:pos>
+                <gml:pos>2.65676714447 48.83981760239</gml:pos>
+                <gml:pos>2.65677832285 48.83977559441</gml:pos>
+                <gml:pos>2.65504209126 48.83957545732</gml:pos>
+                <gml:pos>2.6545744625 48.83952155317</gml:pos>
+                <gml:pos>2.65451054706 48.83951416699</gml:pos>
+                <gml:pos>2.65426997737 48.83948645475</gml:pos>
+                <gml:pos>2.65371665587 48.83942267257</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:2:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" version="any"/>
+          <TransportMode>rail</TransportMode>
+        </Quay>
+        <Quay id="ALM:Quay:w-116869:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>InsideSpace</Key>
+              <Value>Quay</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Level</Key>
+              <Value>1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+          </keyList>
+          <gml:Polygon gml:id="w-116869">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.65673528216 48.83992846433</gml:pos>
+                <gml:pos>2.6567491377 48.83987638607</gml:pos>
+                <gml:pos>2.65368668116 48.83952343977</gml:pos>
+                <gml:pos>2.65367282562 48.83957551839</gml:pos>
+                <gml:pos>2.65673528216 48.83992846433</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:3:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" version="any"/>
+          <TransportMode>rail</TransportMode>
+        </Quay>
+        <StopPlace id="ALM:StopPlace_rail:w-116867:LOC" version="any">
+          <Name>Torcy Marne-la-Vallée</Name>
+          <gml:Polygon gml:id="w-116867_1">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.65366494387 48.8395984018</gml:pos>
+                <gml:pos>2.65367282562 48.83957551839</gml:pos>
+                <gml:pos>2.65368668116 48.83952343977</gml:pos>
+                <gml:pos>2.65370547749 48.83946468085</gml:pos>
+                <gml:pos>2.65371665587 48.83942267257</gml:pos>
+                <gml:pos>2.65428185195 48.83947835802</gml:pos>
+                <gml:pos>2.6545805386 48.83930885125</gml:pos>
+                <gml:pos>2.65471100539 48.83923473887</gml:pos>
+                <gml:pos>2.65505164593 48.83957192158</gml:pos>
+                <gml:pos>2.65677832285 48.83977559441</gml:pos>
+                <gml:pos>2.65676714447 48.83981760239</gml:pos>
+                <gml:pos>2.6567491377 48.83987638607</gml:pos>
+                <gml:pos>2.65673528216 48.83992846433</gml:pos>
+                <gml:pos>2.65671997994 48.8399779501</gml:pos>
+                <gml:pos>2.65443742007 48.83971667995</gml:pos>
+                <gml:pos>2.65441864461 48.8398384885</gml:pos>
+                <gml:pos>2.65408764898 48.83979159193</gml:pos>
+                <gml:pos>2.6539707157 48.83977493625</gml:pos>
+                <gml:pos>2.65394925803 48.83965312755</gml:pos>
+                <gml:pos>2.65366494387 48.8395984018</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <placeTypes>
+            <TypeOfPlaceRef ref="monomodalStopPlace"/>
+          </placeTypes>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:23:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <facilities>
+            <SiteFacilitySet id="ALM:SiteFacilitySet:23:" version="any">
+              <AccessibilityInfoFacilityList>audioInformation audioForHearingImpaired visualDisplays displaysForVisuallyImpaired</AccessibilityInfoFacilityList>
+              <MedicalFacilityList>defibrillator</MedicalFacilityList>
+              <MobilityFacilityList>suitableForWheelchairs tactilePlatformEdges</MobilityFacilityList>
+              <PassengerCommsFacilityList>publicWifi internet</PassengerCommsFacilityList>
+              <PassengerInformationEquipmentList>informationDesk realTimeDepartures</PassengerInformationEquipmentList>
+              <SanitaryFacilityList>none</SanitaryFacilityList>
+              <TicketingFacilityList>ticketMachines ticketOffice mobileTicketing</TicketingFacilityList>
+              <ParkingFacilityList>carPark cyclePark</ParkingFacilityList>
+              <Staffing>partTime</Staffing>
+            </SiteFacilitySet>
+          </facilities>
+          <entrances>
+            <EntranceRef ref="ALM:Entrance:n-144059:LOC" version="any"/>
+            <EntranceRef ref="ALM:Entrance:n-144060:LOC" version="any"/>
+          </entrances>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:230" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144076_23_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketingEquipment:n-144076:LOC" version="any"/>
+                  <Location id="n-144076">
+                    <Longitude>2.65478074417</Longitude>
+                    <Latitude>48.83936978788</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:231" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144075_23_1:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketingEquipment:n-144075:LOC" version="any"/>
+                  <Location id="n-144075">
+                    <Longitude>2.65474587545</Longitude>
+                    <Latitude>48.83944305009</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:232" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144078_23_2:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketValidatorEquipment:n-144078:LOC" version="any"/>
+                  <Location id="n-144078">
+                    <Longitude>2.65457973384</Longitude>
+                    <Latitude>48.83937503016</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:233" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144081_23_3:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketValidatorEquipment:n-144081:LOC" version="any"/>
+                  <Location id="n-144081">
+                    <Longitude>2.65412500627</Longitude>
+                    <Latitude>48.83974215344</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:234" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n-144075_23_4:LOC" version="any">
+                  <EquipmentRef ref="ALM:AssistanceService:n-144075:LOC" version="any"/>
+                  <Location id="n-144075">
+                    <Longitude>2.65474587545</Longitude>
+                    <Latitude>48.83944305009</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+          <placeEquipments>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116873_n-144065_n-144062:LOC"/>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116874_n-144066_n-144063:LOC"/>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116876_n-144068_n-144069:LOC"/>
+            <EscalatorEquipmentRef ref="ALM:EscalatorEquipment:w-116880_n-144072_n-144073:LOC"/>
+            <StaircaseEquipmentRef ref="ALM:StaircaseEquipment:w-116981_n-144082_n-144071:LOC"/>
+          </placeEquipments>
+          <TransportMode>rail</TransportMode>
+          <StopPlaceType>railStation</StopPlaceType>
+          <quays>
+            <QuayRef version="any" ref="ALM:Quay:w-116868:LOC"/>
+            <QuayRef version="any" ref="ALM:Quay:w-116869:LOC"/>
+          </quays>
+          <pathLinks>
+            <PathLinkRef ref="ALM:SitePathLink:n-144056_level-1_level0:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:n-144056_level0_level1:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:n-144057_level-1_level1:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:n-144058_level-1_level0:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116870_n-144060_n-144065:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116871_n-144062_n-144066:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116872_n-144063_n-144059:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116873_n-144065_n-144062:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116874_n-144066_n-144063:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116875_n-144084_n-144056:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116876_n-144068_n-144069:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116877_n-144070_n-144082:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116878_n-144062_n-144072:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116879_n-144073_n-144058:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116880_n-144072_n-144073:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116881_n-144080_n-144058:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116882_n-144057_n-144070:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116887_n-144056_n-144068:LOC" versionRef="any"/>
+            <PathLinkRef ref="ALM:SitePathLink:w-116981_n-144082_n-144071:LOC" versionRef="any"/>
+          </pathLinks>
+        </StopPlace>
+        <Entrance id="ALM:Entrance:n-144059:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AutomaticDoor</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>EntrancePassage</Key>
+              <Value>Door</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbHeight</Key>
+              <Value>0</Value>
+            </KeyValue>
+          </keyList>
+          <Centroid>
+            <Location id="n-144059">
+              <Longitude>2.6545805386</Longitude>
+              <Latitude>48.83930885125</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:0:" version="any">
+            <MobilityImpairedAccess>true</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" version="any"/>
+          <placeEquipments>
+            <EntranceEquipmentRef ref="ALM:EntranceEquipment:n-144059:LOC"/>
+          </placeEquipments>
+          <PublicCode>1</PublicCode>
+          <Label>Gare routière</Label>
+          <EntranceType>automaticDoor</EntranceType>
+          <IsEntry>true</IsEntry>
+          <IsExit>true</IsExit>
+          <Width>2.00</Width>
+        </Entrance>
+        <Entrance id="ALM:Entrance:n-144060:LOC" version="any">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>AutomaticDoor</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>EntrancePassage</Key>
+              <Value>Door</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbHeight</Key>
+              <Value>0</Value>
+            </KeyValue>
+          </keyList>
+          <Centroid>
+            <Location id="n-144060">
+              <Longitude>2.65408764898</Longitude>
+              <Latitude>48.83979159193</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:1:" version="any">
+            <MobilityImpairedAccess>true</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="ALM:StopPlace_rail:w-116867:LOC" version="any"/>
+          <placeEquipments>
+            <EntranceEquipmentRef ref="ALM:EntranceEquipment:n-144060:LOC"/>
+          </placeEquipments>
+          <PublicCode>2</PublicCode>
+          <Label>Rue Léon Blum</Label>
+          <EntranceType>automaticDoor</EntranceType>
+          <IsEntry>true</IsEntry>
+          <IsExit>true</IsExit>
+          <Width>2.00</Width>
+        </Entrance>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_tramstation_example/accessibility.xml
+++ b/exemples/AccesLibreMobilites/ALM_tramstation_example/accessibility.xml
@@ -1,0 +1,834 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement - Cet export contient des données issues d'OpenStreetMap (© contributeurs OpenStreetMap).</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_ACCESSIBILITY:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_ACCESSIBILITY:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <SitePathLink id="ALM:SitePathLink:w136_n762_n768:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Pedestrian</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609984</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>2.34</Distance>
+          <gml:LineString gml:id="w136_n762_n768">
+            <gml:pos>2.0787226 48.8151059</gml:pos>
+            <gml:pos>2.0787175 48.8150851</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n762:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n768:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:6:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>unknown</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Covered>outdoors</Covered>
+          <NumberOfSteps>0</NumberOfSteps>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="FR:StopPlace:StopArea_OCE87710913_rail:" versionRef="+1"/>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w137_n780_n761:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Pedestrian</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609984</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>2.16</Distance>
+          <gml:LineString gml:id="w137_n780_n761">
+            <gml:pos>2.0785686 48.8151028</gml:pos>
+            <gml:pos>2.0785734 48.815122</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n780:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n761:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:7:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>unknown</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Covered>outdoors</Covered>
+          <NumberOfSteps>0</NumberOfSteps>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="FR:StopPlace:StopArea_OCE87710913_rail:" versionRef="+1"/>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w138_n761_n762:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609983</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>11.07</Distance>
+          <gml:LineString gml:id="w138_n761_n762">
+            <gml:pos>2.0785734 48.815122</gml:pos>
+            <gml:pos>2.078626 48.8151163</gml:pos>
+            <gml:pos>2.0786763 48.8151109</gml:pos>
+            <gml:pos>2.0787226 48.8151059</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n761:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n762:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:8:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>unknown</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>unknown</AudibleSignalsAvailable>
+                <VisualSignsAvailable>unknown</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Covered>outdoors</Covered>
+          <NumberOfSteps>0</NumberOfSteps>
+          <AccessFeatureType>crossing</AccessFeatureType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="FR:StopPlace:StopArea_OCE87710913_rail:" versionRef="+1"/>
+          <placeEquipments>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w138_n761_n762:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w139_n761_n792:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Pedestrian</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609975</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>2</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>2.47</Distance>
+          <gml:LineString gml:id="w139_n761_n792">
+            <gml:pos>2.0785734 48.815122</gml:pos>
+            <gml:pos>2.07853985553 48.81512470946</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n761:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:Entrance:n792:LOC" versionRef="1"/>
+            <EntranceRef ref="ALM:Entrance:n792:LOC" versionRef="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:9:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>unknown</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Covered>outdoors</Covered>
+          <NumberOfSteps>0</NumberOfSteps>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:90" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n792_9_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:EntranceEquipment:n792:LOC" version="1"/>
+                  <Location>
+                    <Longitude>2.07853985553</Longitude>
+                    <Latitude>48.81512470946</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w139_n792_n763:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Pedestrian</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609975</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>2</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>0.88</Distance>
+          <gml:LineString gml:id="w139_n792_n763">
+            <gml:pos>2.07853985553 48.81512470946</gml:pos>
+            <gml:pos>2.0785280827 48.8151263</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:Entrance:n792:LOC" versionRef="1"/>
+            <EntranceRef ref="ALM:Entrance:n792:LOC" versionRef="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n763:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:10:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>unknown</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Covered>outdoors</Covered>
+          <NumberOfSteps>0</NumberOfSteps>
+          <AccessFeatureType>footpath</AccessFeatureType>
+          <PassageType>pathway</PassageType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w140_n762_n793:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Pedestrian</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609970</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>1.64</Distance>
+          <gml:LineString gml:id="w140_n762_n793">
+            <gml:pos>2.0787226 48.8151059</gml:pos>
+            <gml:pos>2.07874472413 48.81510337186</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n762:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:Entrance:n793:LOC" versionRef="1"/>
+            <EntranceRef ref="ALM:Entrance:n793:LOC" versionRef="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:11:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>unknown</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Covered>outdoors</Covered>
+          <NumberOfSteps>0</NumberOfSteps>
+          <Transition>up</Transition>
+          <AccessFeatureType>ramp</AccessFeatureType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:110" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n793_11_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:EntranceEquipment:n793:LOC" version="1"/>
+                  <Location>
+                    <Longitude>2.07874472413</Longitude>
+                    <Latitude>48.81510337186</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+          <placeEquipments>
+            <RampEquipmentRef ref="ALM:RampEquipment:w140_n762_n753:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w140_n793_n753:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Pedestrian</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609970</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>6.32</Distance>
+          <gml:LineString gml:id="w140_n793_n753">
+            <gml:pos>2.07874472413 48.81510337186</gml:pos>
+            <gml:pos>2.07877577333 48.81510013245</gml:pos>
+            <gml:pos>2.07878416711 48.81513584684</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:Entrance:n793:LOC" versionRef="1"/>
+            <EntranceRef ref="ALM:Entrance:n793:LOC" versionRef="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n753:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:12:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>unknown</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Covered>outdoors</Covered>
+          <NumberOfSteps>0</NumberOfSteps>
+          <Transition>up</Transition>
+          <AccessFeatureType>ramp</AccessFeatureType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <placeEquipments>
+            <RampEquipmentRef ref="ALM:RampEquipment:w140_n762_n753:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <SitePathLink id="ALM:SitePathLink:w141_n776_n784:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609983</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Distance>7.49</Distance>
+          <gml:LineString gml:id="w141_n776_n784">
+            <gml:pos>2.0785808 48.8144893</gml:pos>
+            <gml:pos>2.0785535 48.8144899</gml:pos>
+            <gml:pos>2.0784996 48.8144911</gml:pos>
+            <gml:pos>2.0784785 48.8144915</gml:pos>
+          </gml:LineString>
+          <From>
+            <PlaceRef ref="ALM:PathJunction:n776:LOC" version="1"/>
+          </From>
+          <To>
+            <PlaceRef ref="ALM:PathJunction:n784:LOC" version="1"/>
+          </To>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:13:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>unknown</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+                <EscalatorFreeAccess>true</EscalatorFreeAccess>
+                <LiftFreeAccess>true</LiftFreeAccess>
+                <AudibleSignalsAvailable>unknown</AudibleSignalsAvailable>
+                <VisualSignsAvailable>unknown</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <PublicUse>all</PublicUse>
+          <Covered>outdoors</Covered>
+          <NumberOfSteps>0</NumberOfSteps>
+          <AccessFeatureType>crossing</AccessFeatureType>
+          <TactileWarningStrip>unknown</TactileWarningStrip>
+          <SiteRef ref="FR:StopPlace:StopArea_OCE87710913_rail:" versionRef="+1"/>
+          <placeEquipments>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w141_n776_n784:LOC"/>
+          </placeEquipments>
+        </SitePathLink>
+        <EntranceEquipment id="ALM:EntranceEquipment:n792:LOC" version="1">
+          <Width>6.00</Width>
+          <Door>false</Door>
+          <Barrier>false</Barrier>
+          <DropKerbOutside>true</DropKerbOutside>
+          <WheelchairPassable>true</WheelchairPassable>
+          <NecessaryForceToOpen>noForce</NecessaryForceToOpen>
+        </EntranceEquipment>
+        <EntranceEquipment id="ALM:EntranceEquipment:n793:LOC" version="1">
+          <Width>6.00</Width>
+          <Door>false</Door>
+          <Barrier>false</Barrier>
+          <DropKerbOutside>true</DropKerbOutside>
+          <WheelchairPassable>true</WheelchairPassable>
+          <NecessaryForceToOpen>noForce</NecessaryForceToOpen>
+        </EntranceEquipment>
+        <TicketingEquipment id="ALM:TicketingEquipment:n755:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Amenity</Key>
+              <Value>TicketVendingMachine</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Obstacle</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ObstacleType</Key>
+              <Value>Ground</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10108104596</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>WheelchairAccess</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+          </keyList>
+          <TicketMachines>true</TicketMachines>
+          <WheelchairSuitable>true</WheelchairSuitable>
+        </TicketingEquipment>
+        <TicketValidatorEquipment id="ALM:TicketValidatorEquipment:n756:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Amenity</Key>
+              <Value>TicketValidator</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10108104608</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+        </TicketValidatorEquipment>
+        <PassengerSafetyEquipment id="ALM:PassengerSafetyEquipment:n757:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Amenity</Key>
+              <Value>EmergencyPhone</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Obstacle</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ObstacleType</Key>
+              <Value>Ground</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>PublicCode</Key>
+              <Value>4588</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10108104549</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>2</Value>
+            </KeyValue>
+          </keyList>
+        </PassengerSafetyEquipment>
+        <PassengerSafetyEquipment id="ALM:PassengerSafetyEquipment:n758:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Amenity</Key>
+              <Value>EmergencyPhone</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Obstacle</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>ObstacleType</Key>
+              <Value>Ground</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>PublicCode</Key>
+              <Value>4589</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10108104548</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>2</Value>
+            </KeyValue>
+          </keyList>
+        </PassengerSafetyEquipment>
+        <ShelterEquipment id="ALM:ShelterEquipment:n772:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Amenity</Key>
+              <Value>Shelter</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Obstacle</Key>
+              <Value>Shelter</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Geometry:Id</Key>
+              <Value>w1106617145</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10126319945</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+        </ShelterEquipment>
+        <ShelterEquipment id="ALM:ShelterEquipment:n788:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Amenity</Key>
+              <Value>Shelter</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Obstacle</Key>
+              <Value>Shelter</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Geometry:Id</Key>
+              <Value>w1106617144</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10126319941</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+        </ShelterEquipment>
+        <CrossingEquipment id="ALM:CrossingEquipment:w138_n761_n762:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609983</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <DirectionOfUse>both</DirectionOfUse>
+          <CrossingType>levelCrossing</CrossingType>
+          <AcousticCrossingAids>false</AcousticCrossingAids>
+          <TactileWarningStrip>noTactileStrip</TactileWarningStrip>
+          <DroppedKerb>false</DroppedKerb>
+          <MarkingStatus>unknown</MarkingStatus>
+        </CrossingEquipment>
+        <RampEquipment id="ALM:RampEquipment:w140_n762_n753:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Pedestrian</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Incline</Key>
+              <Value>Up</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609970</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Length>7.96</Length>
+          <HandrailType>bothSides</HandrailType>
+          <Temporary>false</Temporary>
+        </RampEquipment>
+        <CrossingEquipment id="ALM:CrossingEquipment:w141_n776_n784:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>HighwayType</Key>
+              <Value>Street</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609983</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <DirectionOfUse>both</DirectionOfUse>
+          <CrossingType>levelCrossing</CrossingType>
+          <AcousticCrossingAids>false</AcousticCrossingAids>
+          <TactileWarningStrip>noTactileStrip</TactileWarningStrip>
+          <DroppedKerb>false</DroppedKerb>
+          <MarkingStatus>unknown</MarkingStatus>
+        </CrossingEquipment>
+        <PathJunction id="ALM:PathJunction:n762:LOC" version="1">
+          <Location id="n762">
+            <Longitude>2.0787226</Longitude>
+            <Latitude>48.8151059</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n768:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10108104603</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n768">
+            <Longitude>2.0787175</Longitude>
+            <Latitude>48.8150851</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n780:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10108104607</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n780">
+            <Longitude>2.0785686</Longitude>
+            <Latitude>48.8151028</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n761:LOC" version="1">
+          <Location id="n761">
+            <Longitude>2.0785734</Longitude>
+            <Latitude>48.815122</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n763:LOC" version="1">
+          <Location id="n763">
+            <Longitude>2.0785280827</Longitude>
+            <Latitude>48.8151263</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n753:LOC" version="1">
+          <Location id="n753">
+            <Longitude>2.07878416711</Longitude>
+            <Latitude>48.81513584684</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n776:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10108104600</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n776">
+            <Longitude>2.0785808</Longitude>
+            <Latitude>48.8144893</Latitude>
+          </Location>
+        </PathJunction>
+        <PathJunction id="ALM:PathJunction:n784:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10108104597</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Location id="n784">
+            <Longitude>2.0784785</Longitude>
+            <Latitude>48.8144915</Latitude>
+          </Location>
+        </PathJunction>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_tramstation_example/poi.xml
+++ b/exemples/AccesLibreMobilites/ALM_tramstation_example/poi.xml
@@ -1,0 +1,171 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement - Cet export contient des données issues d'OpenStreetMap (© contributeurs OpenStreetMap).</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_COMMUN:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_COMMUN:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <PointOfInterest id="ALM:PointOfInterest:w142:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>PointOfInterest</Key>
+              <Value>StopPlace</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Export:Id</Key>
+              <Value>FR:StopPlace:StopArea_OCE87710913_rail:</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609969</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>2</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Allée Royale</Name>
+          <gml:Polygon gml:id="w142">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.07874897747 48.81512011572</gml:pos>
+                <gml:pos>2.07874472413 48.81510337186</gml:pos>
+                <gml:pos>2.0787396 48.8150832</gml:pos>
+                <gml:pos>2.0786862 48.8148024</gml:pos>
+                <gml:pos>2.0786792 48.8147571</gml:pos>
+                <gml:pos>2.0786644 48.8146525</gml:pos>
+                <gml:pos>2.0786597 48.8146231</gml:pos>
+                <gml:pos>2.0786405 48.8144747</gml:pos>
+                <gml:pos>2.0785795 48.8144759</gml:pos>
+                <gml:pos>2.0784762 48.8144779</gml:pos>
+                <gml:pos>2.0784212 48.814479</gml:pos>
+                <gml:pos>2.0784491 48.8146421</gml:pos>
+                <gml:pos>2.0784548 48.8146675</gml:pos>
+                <gml:pos>2.0784734 48.8147667</gml:pos>
+                <gml:pos>2.0784864 48.8148289</gml:pos>
+                <gml:pos>2.0785417 48.8151052</gml:pos>
+                <gml:pos>2.07853985553 48.81512470946</gml:pos>
+                <gml:pos>2.07854171568 48.81513712257</gml:pos>
+                <gml:pos>2.07874897747 48.81512011572</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:15:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>unknown</WheelchairAccess>
+                <StepFreeAccess>unknown</StepFreeAccess>
+                <EscalatorFreeAccess>unknown</EscalatorFreeAccess>
+                <LiftFreeAccess>unknown</LiftFreeAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <facilities>
+            <SiteFacilitySet id="ALM:SiteFacilitySet:15:" version="any">
+              <AccessibilityInfoFacilityList>audioInformation visualDisplays displaysForVisuallyImpaired</AccessibilityInfoFacilityList>
+              <MobilityFacilityList>tactilePlatformEdges</MobilityFacilityList>
+              <TicketingFacilityList>ticketMachines</TicketingFacilityList>
+              <EmergencyServiceList>sosPoint</EmergencyServiceList>
+              <ParkingFacilityList>carPark</ParkingFacilityList>
+            </SiteFacilitySet>
+          </facilities>
+          <entrances>
+            <EntranceRef ref="ALM:Entrance:n793:LOC" version="1"/>
+            <EntranceRef ref="ALM:Entrance:n792:LOC" version="1"/>
+          </entrances>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:150" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n772_15_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:ShelterEquipment:n772:LOC" version="1"/>
+                  <Location id="n772">
+                    <Longitude>2.0786644</Longitude>
+                    <Latitude>48.8146525</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:151" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n788_15_1:LOC" version="any">
+                  <EquipmentRef ref="ALM:ShelterEquipment:n788:LOC" version="1"/>
+                  <Location id="n788">
+                    <Longitude>2.0784548</Longitude>
+                    <Latitude>48.8146675</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:152" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n755_15_2:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketingEquipment:n755:LOC" version="1"/>
+                  <Location id="n755">
+                    <Longitude>2.0786456</Longitude>
+                    <Latitude>48.8147225</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:153" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n756_15_3:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketValidatorEquipment:n756:LOC" version="1"/>
+                  <Location id="n756">
+                    <Longitude>2.0785584</Longitude>
+                    <Latitude>48.8151101</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:154" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n758_15_4:LOC" version="any">
+                  <EquipmentRef ref="ALM:PassengerSafetyEquipment:n758:LOC" version="1"/>
+                  <Location id="n758">
+                    <Longitude>2.0786591</Longitude>
+                    <Latitude>48.8146719</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:155" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n757_15_5:LOC" version="any">
+                  <EquipmentRef ref="ALM:PassengerSafetyEquipment:n757:LOC" version="1"/>
+                  <Location id="n757">
+                    <Longitude>2.078469</Longitude>
+                    <Latitude>48.8146842</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+          <placeEquipments>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w138_n761_n762:LOC"/>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w141_n776_n784:LOC"/>
+          </placeEquipments>
+          <pathLinks>
+            <PathLinkRef ref="ALM:SitePathLink:w136_n762_n768:LOC" versionRef="1"/>
+            <PathLinkRef ref="ALM:SitePathLink:w137_n780_n761:LOC" versionRef="1"/>
+            <PathLinkRef ref="ALM:SitePathLink:w138_n761_n762:LOC" versionRef="1"/>
+            <PathLinkRef ref="ALM:SitePathLink:w141_n776_n784:LOC" versionRef="1"/>
+          </pathLinks>
+        </PointOfInterest>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_tramstation_example/resource.xml
+++ b/exemples/AccesLibreMobilites/ALM_tramstation_example/resource.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement - Cet export contient des données issues d'OpenStreetMap (© contributeurs OpenStreetMap).</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_COMMUN:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_COMMUN:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <DataSource id="FR:ALM:DataSource:ALMUser" version="any">
+          <Name>Une instance AccèsLibre Mobilités</Name>
+          <Description>Accèslibre Mobilités est une suite logicielle qui permet aux collectivités de collecter, créer et publier les données d'accessibilité des transports et de la voirie.</Description>
+          <DataLicenceCode ref="ODbL-1.0"/>
+          <DataLicenceUrl>https://opendatacommons.org/licenses/odbl/1-0/</DataLicenceUrl>
+        </DataSource>
+        <DataSource id="FR:ALM:DataSource:OpenStreetMap" version="any">
+          <Name>OpenStreetMap</Name>
+          <Description>OpenStreetMap est un ensemble de données ouvertes, disponible sous la licence libre ODbL accordée par la Fondation OpenStreetMap</Description>
+          <DataLicenceCode ref="ODbL-1.0"/>
+          <DataLicenceUrl>https://wiki.osmfoundation.org/wiki/Licence</DataLicenceUrl>
+        </DataSource>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/ALM_tramstation_example/stop.xml
+++ b/exemples/AccesLibreMobilites/ALM_tramstation_example/stop.xml
@@ -1,0 +1,492 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://www.govtalk.gov.uk/core" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.09:FR-NETEX-2.3-0.0" xsi:schemaLocation="http://www.netex.org.uk/netex">
+  <PublicationTimestamp>2022-12-07T12:00:00</PublicationTimestamp>
+  <ParticipantRef>ALM_wdm2netex</ParticipantRef>
+  <Description>Export AccèsLibre Mobilités des données d'accessibilité et de cheminement - Cet export contient des données issues d'OpenStreetMap (© contributeurs OpenStreetMap).</Description>
+  <dataObjects>
+    <GeneralFrame id="FR:GeneralFrame:NETEX_ARRET:LOC" version="1.09:FR-NETEX-2.3-0.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_ARRET:"/>
+      <FrameDefaults>
+        <DefaultLocationSystem>EPSG:4326</DefaultLocationSystem>
+      </FrameDefaults>
+      <members>
+        <Quay id="FR::Quay:480934:FR1" version="+1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>InsideSpace</Key>
+              <Value>Quay</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1074554618</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>8</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Seating</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Shelter</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_id">
+              <Key>Id</Key>
+              <Value>w143</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_id">
+              <Key>Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Voie 2C</Name>
+          <gml:Polygon gml:id="w143">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.0786922 48.8150872</gml:pos>
+                <gml:pos>2.0786349 48.8148112</gml:pos>
+                <gml:pos>2.0786013 48.8146249</gml:pos>
+                <gml:pos>2.0785808 48.8144893</gml:pos>
+                <gml:pos>2.0785795 48.8144759</gml:pos>
+                <gml:pos>2.0786405 48.8144747</gml:pos>
+                <gml:pos>2.0786597 48.8146231</gml:pos>
+                <gml:pos>2.0786644 48.8146525</gml:pos>
+                <gml:pos>2.0786792 48.8147571</gml:pos>
+                <gml:pos>2.0786862 48.8148024</gml:pos>
+                <gml:pos>2.0787396 48.8150832</gml:pos>
+                <gml:pos>2.0787175 48.8150851</gml:pos>
+                <gml:pos>2.0786922 48.8150872</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:4:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <Lighting>wellLit</Lighting>
+          <SiteRef ref="FR:StopPlace:StopArea_OCE87710913_rail:" version="+1"/>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:40" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n772_4_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:ShelterEquipment:n772:LOC" version="1"/>
+                  <Location id="n772">
+                    <Longitude>2.0786644</Longitude>
+                    <Latitude>48.8146525</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:41" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n755_4_1:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketingEquipment:n755:LOC" version="1"/>
+                  <Location id="n755">
+                    <Longitude>2.0786456</Longitude>
+                    <Latitude>48.8147225</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:42" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n758_4_2:LOC" version="any">
+                  <EquipmentRef ref="ALM:PassengerSafetyEquipment:n758:LOC" version="1"/>
+                  <Location id="n758">
+                    <Longitude>2.0786591</Longitude>
+                    <Latitude>48.8146719</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+          <TransportMode>tram</TransportMode>
+          <PublicCode>2C</PublicCode>
+        </Quay>
+        <Quay id="FR::Quay:481074:FR1" version="+1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>FixMe:TactileWarningStrip</Key>
+              <Value>Vérifier l’état du marquage de la bande d’éveil à vigilance</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>InsideSpace</Key>
+              <Value>Quay</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1074554617</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>8</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Seating</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Shelter</Key>
+              <Value>Yes</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>TactileWarningStrip</Key>
+              <Value>Good</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_id">
+              <Key>Id</Key>
+              <Value>w144</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_id">
+              <Key>Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Voie 1C</Name>
+          <gml:Polygon gml:id="w144">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.0785417 48.8151052</gml:pos>
+                <gml:pos>2.0784864 48.8148289</gml:pos>
+                <gml:pos>2.0784734 48.8147667</gml:pos>
+                <gml:pos>2.0784548 48.8146675</gml:pos>
+                <gml:pos>2.0784491 48.8146421</gml:pos>
+                <gml:pos>2.0784212 48.814479</gml:pos>
+                <gml:pos>2.0784762 48.8144779</gml:pos>
+                <gml:pos>2.0784785 48.8144915</gml:pos>
+                <gml:pos>2.0785008 48.8146319</gml:pos>
+                <gml:pos>2.0785363 48.8148196</gml:pos>
+                <gml:pos>2.078591 48.8151008</gml:pos>
+                <gml:pos>2.0785686 48.8151028</gml:pos>
+                <gml:pos>2.0785417 48.8151052</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:5:" version="any">
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>false</WheelchairAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <Lighting>wellLit</Lighting>
+          <SiteRef ref="FR:StopPlace:StopArea_OCE87710913_rail:" version="+1"/>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:50" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n788_5_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:ShelterEquipment:n788:LOC" version="1"/>
+                  <Location id="n788">
+                    <Longitude>2.0784548</Longitude>
+                    <Latitude>48.8146675</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:51" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n757_5_1:LOC" version="any">
+                  <EquipmentRef ref="ALM:PassengerSafetyEquipment:n757:LOC" version="1"/>
+                  <Location id="n757">
+                    <Longitude>2.078469</Longitude>
+                    <Latitude>48.8146842</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+          <TransportMode>tram</TransportMode>
+          <PublicCode>1C</PublicCode>
+        </Quay>
+        <StopPlace id="FR:StopPlace:StopArea_OCE87710913_rail:" version="+1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>w1104609969</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>2</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_id">
+              <Key>Id</Key>
+              <Value>w142</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_id">
+              <Key>Version</Key>
+              <Value>1</Value>
+            </KeyValue>
+          </keyList>
+          <Name>Allée Royale</Name>
+          <gml:Polygon gml:id="w142_1">
+            <gml:exterior>
+              <gml:LinearRing>
+                <gml:pos>2.07874897747 48.81512011572</gml:pos>
+                <gml:pos>2.07874472413 48.81510337186</gml:pos>
+                <gml:pos>2.0787396 48.8150832</gml:pos>
+                <gml:pos>2.0786862 48.8148024</gml:pos>
+                <gml:pos>2.0786792 48.8147571</gml:pos>
+                <gml:pos>2.0786644 48.8146525</gml:pos>
+                <gml:pos>2.0786597 48.8146231</gml:pos>
+                <gml:pos>2.0786405 48.8144747</gml:pos>
+                <gml:pos>2.0785795 48.8144759</gml:pos>
+                <gml:pos>2.0784762 48.8144779</gml:pos>
+                <gml:pos>2.0784212 48.814479</gml:pos>
+                <gml:pos>2.0784491 48.8146421</gml:pos>
+                <gml:pos>2.0784548 48.8146675</gml:pos>
+                <gml:pos>2.0784734 48.8147667</gml:pos>
+                <gml:pos>2.0784864 48.8148289</gml:pos>
+                <gml:pos>2.0785417 48.8151052</gml:pos>
+                <gml:pos>2.07853985553 48.81512470946</gml:pos>
+                <gml:pos>2.07854171568 48.81513712257</gml:pos>
+                <gml:pos>2.07874897747 48.81512011572</gml:pos>
+              </gml:LinearRing>
+            </gml:exterior>
+          </gml:Polygon>
+          <placeTypes>
+            <TypeOfPlaceRef ref="monomodalStopPlace"/>
+          </placeTypes>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:14:" version="any">
+            <validityConditions>
+              <ValidityCondition id="ALM:ValidityCondition:14:" version="any">
+                <Description>Présence inconnue d'un cheminement pratiquable en fauteuil roulant entre les quais</Description>
+              </ValidityCondition>
+            </validityConditions>
+            <MobilityImpairedAccess>unknown</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>partial</WheelchairAccess>
+                <StepFreeAccess>unknown</StepFreeAccess>
+                <EscalatorFreeAccess>unknown</EscalatorFreeAccess>
+                <LiftFreeAccess>unknown</LiftFreeAccess>
+                <AudibleSignalsAvailable>true</AudibleSignalsAvailable>
+                <VisualSignsAvailable>true</VisualSignsAvailable>
+                <TactileGuidanceAvailable>unknown</TactileGuidanceAvailable>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <facilities>
+            <SiteFacilitySet id="ALM:SiteFacilitySet:14:" version="any">
+              <AccessibilityInfoFacilityList>audioInformation visualDisplays displaysForVisuallyImpaired</AccessibilityInfoFacilityList>
+              <MobilityFacilityList>tactilePlatformEdges</MobilityFacilityList>
+              <TicketingFacilityList>ticketMachines</TicketingFacilityList>
+              <EmergencyServiceList>sosPoint</EmergencyServiceList>
+              <ParkingFacilityList>carPark</ParkingFacilityList>
+            </SiteFacilitySet>
+          </facilities>
+          <entrances>
+            <EntranceRef ref="ALM:Entrance:n793:LOC" version="1"/>
+            <EntranceRef ref="ALM:Entrance:n792:LOC" version="1"/>
+          </entrances>
+          <equipmentPlaces>
+            <EquipmentPlace id="ALM:EquipmentPlace:140" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n772_14_0:LOC" version="any">
+                  <EquipmentRef ref="ALM:ShelterEquipment:n772:LOC" version="1"/>
+                  <Location id="n772">
+                    <Longitude>2.0786644</Longitude>
+                    <Latitude>48.8146525</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:141" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n788_14_1:LOC" version="any">
+                  <EquipmentRef ref="ALM:ShelterEquipment:n788:LOC" version="1"/>
+                  <Location id="n788">
+                    <Longitude>2.0784548</Longitude>
+                    <Latitude>48.8146675</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:142" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n755_14_2:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketingEquipment:n755:LOC" version="1"/>
+                  <Location id="n755">
+                    <Longitude>2.0786456</Longitude>
+                    <Latitude>48.8147225</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:143" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n756_14_3:LOC" version="any">
+                  <EquipmentRef ref="ALM:TicketValidatorEquipment:n756:LOC" version="1"/>
+                  <Location id="n756">
+                    <Longitude>2.0785584</Longitude>
+                    <Latitude>48.8151101</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:144" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n758_14_4:LOC" version="any">
+                  <EquipmentRef ref="ALM:PassengerSafetyEquipment:n758:LOC" version="1"/>
+                  <Location id="n758">
+                    <Longitude>2.0786591</Longitude>
+                    <Latitude>48.8146719</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+            <EquipmentPlace id="ALM:EquipmentPlace:145" version="any">
+              <equipmentPositions>
+                <EquipmentPosition id="ALM:EquipmentPosition:n757_14_5:LOC" version="any">
+                  <EquipmentRef ref="ALM:PassengerSafetyEquipment:n757:LOC" version="1"/>
+                  <Location id="n757">
+                    <Longitude>2.078469</Longitude>
+                    <Latitude>48.8146842</Latitude>
+                  </Location>
+                </EquipmentPosition>
+              </equipmentPositions>
+            </EquipmentPlace>
+          </equipmentPlaces>
+          <placeEquipments>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w138_n761_n762:LOC"/>
+            <CrossingEquipmentRef ref="ALM:CrossingEquipment:w141_n776_n784:LOC"/>
+          </placeEquipments>
+          <TransportMode>tram</TransportMode>
+          <StopPlaceType>tramStation</StopPlaceType>
+          <quays>
+            <QuayRef version="+1" ref="FR::Quay:480934:FR1"/>
+            <QuayRef version="+1" ref="FR::Quay:481074:FR1"/>
+          </quays>
+          <pathLinks>
+            <PathLinkRef ref="ALM:SitePathLink:w136_n762_n768:LOC" versionRef="1"/>
+            <PathLinkRef ref="ALM:SitePathLink:w137_n780_n761:LOC" versionRef="1"/>
+            <PathLinkRef ref="ALM:SitePathLink:w138_n761_n762:LOC" versionRef="1"/>
+            <PathLinkRef ref="ALM:SitePathLink:w141_n776_n784:LOC" versionRef="1"/>
+          </pathLinks>
+        </StopPlace>
+        <Entrance id="ALM:Entrance:n792:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>EntrancePassage</Key>
+              <Value>Opening</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbHeight</Key>
+              <Value>0</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10108104557</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>2</Value>
+            </KeyValue>
+          </keyList>
+          <Centroid>
+            <Location id="n792">
+              <Longitude>2.07853985553</Longitude>
+              <Latitude>48.81512470946</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:0:" version="any">
+            <MobilityImpairedAccess>true</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="FR:StopPlace:StopArea_OCE87710913_rail:" version="+1"/>
+          <placeEquipments>
+            <EntranceEquipmentRef ref="ALM:EntranceEquipment:n792:LOC"/>
+          </placeEquipments>
+          <EntranceType>opening</EntranceType>
+          <IsEntry>true</IsEntry>
+          <IsExit>true</IsExit>
+          <Width>6.00</Width>
+        </Entrance>
+        <Entrance id="ALM:Entrance:n793:LOC" version="1">
+          <keyList>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>EntrancePassage</Key>
+              <Value>Opening</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>KerbHeight</Key>
+              <Value>0</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Id</Key>
+              <Value>n10108104554</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Source</Key>
+              <Value>OpenStreetMap</Value>
+            </KeyValue>
+            <KeyValue typeOfKey="WDM_tag">
+              <Key>Ref:Import:Version</Key>
+              <Value>2</Value>
+            </KeyValue>
+          </keyList>
+          <Centroid>
+            <Location id="n793">
+              <Longitude>2.07874472413</Longitude>
+              <Latitude>48.81510337186</Latitude>
+            </Location>
+          </Centroid>
+          <AccessibilityAssessment id="ALM:AccessibilityAssessment:1:" version="any">
+            <MobilityImpairedAccess>true</MobilityImpairedAccess>
+            <limitations>
+              <AccessibilityLimitation>
+                <WheelchairAccess>true</WheelchairAccess>
+                <StepFreeAccess>true</StepFreeAccess>
+              </AccessibilityLimitation>
+            </limitations>
+          </AccessibilityAssessment>
+          <SiteRef ref="FR:StopPlace:StopArea_OCE87710913_rail:" version="+1"/>
+          <placeEquipments>
+            <EntranceEquipmentRef ref="ALM:EntranceEquipment:n793:LOC"/>
+          </placeEquipments>
+          <EntranceType>opening</EntranceType>
+          <IsEntry>true</IsEntry>
+          <IsExit>true</IsExit>
+          <Width>6.00</Width>
+        </Entrance>
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/exemples/AccesLibreMobilites/readme.md
+++ b/exemples/AccesLibreMobilites/readme.md
@@ -1,0 +1,19 @@
+# Exemples AccèsLibre Mobilités
+
+Ce dossier propose quelques exemples de fichiers générés avec [AccèsLibre Mobilités](https://mtes-mct.github.io/alm-docs/) (ALM), la suite logicielle *open source* à destination des collectivités territoriales pour collecter, créer et publier les données d'accessibilité des transports et de la voirie.
+
+## ALM_onstreetbus_example
+
+Cet exemple illustre un cas d'usage classique de voirie piétonne autour de deux arrêts de bus en extérieur.
+
+On y retrouve des arrêts de bus, des trottoirs, des passages piétons, quelques petits escaliers, une rampe PMR, une place stationnement réservée PMR, quelques ERP ainsi que leurs entrées, etc.
+
+## ALM_tramstation_example
+
+Cet exemple modélise une station de tramway, avec ses deux quais, les passages à niveau permettant de passer d'un quai à l'autre, et quelques équipements qu'on retrouve régulièrement dans les stations (billettique, téléphone d'urgence, etc).
+
+De plus, il s'agit d'un exemple d'import de données depuis OpenStreetMap, la base de données cartographique libre.
+
+## ALM_railstation_example
+
+Cet exemple modélise l'intérieur d'une petite gare, avec deux quais et deux bâtiments voyageurs. Les cheminements incluent notamment un tunnel, plusieurs ascenseurs, escaliers, escalator, etc.


### PR DESCRIPTION
Voici 3 "fichiers" d'exemples (en fait plutôt des dossiers, pour respecter la nouvelle structure d'export) issus des cas d'usages couverts par ALM, ainsi qu'une petite description accompagnant chaque fichier.