### PR TITLE
Accessibilite attributs partagés

### DIFF
--- a/NeTEx/accessibilite/index.md
+++ b/NeTEx/accessibilite/index.md
@@ -1071,9 +1071,9 @@ traduit) car c'est sous cette dénomination que les objets présentés se
 retrouveront dans le modèle XSD et donc dans les tags XML utilisés dans
 l'implémentation et les échanges.
 
-## Éléments d'accessibilité de base partagés par tous les profils
+## Éléments d'accessibilité de base partagés par toutes les parties du profil France
 
-Les profils précédents (Éléments Communs, Arrêts, Réseaux et Horaires)
+Les autres parties du profil France (Éléments Communs, Arrêts, Réseaux, Horaires, Tarifs et Parking)
 proposent déjà une information de base sur l'accessibilité en utilisant 
 les ÉVALUATIONs D’ACCESSIBILITÉ (ACCESSIBILITY ASSESSMENT) :
 
@@ -1107,7 +1107,7 @@ gare, accès possibles pour les UFR uniquement sur certains quais)
 signalétique auditive en cas de perturbations mais pas d'annonces pour
 les prochains passages)
 
-<span class="hl">Dans le cadre du profil il est convenu, lorsque
+<span class="hl">Dans le cadre du profil France il est convenu, lorsque
 "</span>***<span class="hl">Partiel</span>***<span class="hl">" est
 utilisé, de systématiquement remplir le champ "</span>***<span
 class="hl">ValidityCondition->Description</span>***<span class="hl">"
@@ -1118,7 +1118,7 @@ texte libre susceptible d'être présenté au public en complément des
 indicateurs ci-dessus.</span>
 
 ![image](media/image8.svg)
-*Accessibilité des profils précédents*
+*Accessibilité des autres parties du profil France*
 
 Toutefois, cela correspond à une information globale et synthétique,
 mais qui dans de nombreuses situations manquera de précisions, d'une

--- a/NeTEx/arrets/index.md
+++ b/NeTEx/arrets/index.md
@@ -63,23 +63,25 @@ traite aussi l’ensemble des concepts nécessaires en entrée et sortie des
 systèmes de planification de l'offre (graphiquage, etc.) et des SAE
 (Systèmes d’Aide à l’Exploitation).
 
-NeTEx se décompose en trois parties:
+NeTEx se décompose en six parties:
 
 -   Partie 1 : topologie des réseaux (les réseaux, les lignes, les
     parcours commerciaux les missions commerciales, les arrêts et lieux
     d’arrêts, les correspondances et les éléments géographiques en se
     limitant au strict minimum pour l’information voyageur)
 
-
-
 -   Partie 2 : horaires théoriques (les courses commerciales, les heures
     de passage graphiquées, les jours types associés ainsi que les
     versions des horaires)
 
-
-
 -   Partie 3 : information tarifaire (uniquement à vocation
     d’information voyageur)
+
+-   Partie 4 : profil européen pour l'information voyageur (EPIP)
+
+-   Partie 5 : nouveaux modes (les véhicules partagés en libre service, les courses partagées, etc.)
+
+-   Partie 6 : profil européen pour l'information voyageur en lien avec l'accessibilité (EPIAP)
 
 NeTEx a été développé dans le cadre du CEN/TC278/WG3/SG9 piloté par la
 France. Les parties 1 et 2 ont été publiées en tant que spécification
@@ -146,39 +148,15 @@ des informations comme :
 
 -   etc.
 
-Les principaux profils actuellement utilisés en France sont NEPTUNE
-(profil de TRIDENT) et le profil de SIRI défini par le CEREMA et le
-STIF. Ces deux profils ont une vocation nationale.
+Ce document présente la partie Arrêts du profil France de NeTEx, tel que défini par le Groupe de Travail dédié à l'information voyageur et à l'exploitation des services de mobilité (GT7) au sein de la Commission Nationale de normalisation pour le transport public (CN03).
 
-Le groupe de travail Qualité des données de l’AFIMB (Agence Française
-pour l’Information Multimodale et la Billettique) a engagé une démarche
-pour définir, sous la forme d’un « référentiel », les caractéristiques
-et exigences de qualité des données transport à recommander. Ces travaux
-ont, entre autres, permis d’élaborer un modèle d’arrêt partagé à partir
-du cadre fixé par les documents de normalisation (Transmodel et NeTEx).
-Ce modèle permet notamment de :
-
--   Proposer une structuration et une hiérarchisation des arrêts
-    (clarifier les concepts de lieu d’arrêt, arrêt physique, arrêt
-    commercial, etc.) ;
-
-
-
--   Décrire les caractéristiques souhaitées pour les arrêts de ce modèle
-    et les exigences de qualité pour ces caractéristiques ;
-
-Le profil présenté dans ce document permet d’échanger l’intégralité des
-informations qui ont été retenues dans le cadre de ce modèle d’arrêt
-partagé.
-
-D'autre profils de NeTEx sont disponibles (réseau, horaire, tarif). Ils
+D'autres parties du profil France de NeTEx sont disponibles (réseau, horaire, tarif, accessibilité, parking). Ils
 sont tous complémentaires les uns des autres (sans recouvrement) et
-s'appuient tous sur le document: **NeTEx - Profil Français de NETEx:
-éléments communs.** Il conviendra de se référer à ce document pour tous
+s'appuient tous sur le document: **NeTEx - Profil France - Éléments communs.** Il conviendra de se référer à ce document pour tous
 les éléments utilisés dans le présent document, et dont la structure
 n'est pas détaillée.
 
-Ce profil d’échange a pour objectif de décrire et de structurer
+Cette partie du profil d’échange a pour objectif de décrire et de structurer
 précisément les éléments nécessaires à une bonne information de
 description des arrêts de transport public de façon :
 
@@ -200,7 +178,7 @@ NeTEx sera nécessaire à sa bonne compréhension.
 
 # Domaine d'application
 
-Le présent document constitue le profil de la CEN/TS 16614 (NeTEx) pour
+Le présent document constitue la partie du profil France de la CEN/TS 16614 (NeTEx) pour
 l'échange de données de description d'arrêt en France. Il permet de
 décrire les arrêts de transports publics et la manière dont ils pourront
 être structurés pour des échanges entre systèmes d'information ainsi que
@@ -779,7 +757,7 @@ Au-delà du Profil Arrêt, les informations d’adresse sont donc attendues pour
 <td><strong>STOP PLACE</strong></td>
 <td><p><strong>QUAY<br />
 </strong></p>
-<p><em>(profil réseau)</em></p>
+<p><em>(partie réseau)</em></p>
 <p><strong>SCHEDULED STOP POINT<br />
 PASSENGER STOP ASSIGNMENT</strong></p></td>
 <td></td>
@@ -797,7 +775,7 @@ PASSENGER STOP ASSIGNMENT</strong></p></td>
 <td><em><strong>Trip plan computation — scheduled modes transport</strong></em></td>
 <td>Stop facilities access nodes (including platform information, help desks/information points, ticket booths, lifts/stairs, entrances and exit locations)</td>
 <td><strong>STOP PLACE's FACILITIES</strong></td>
-<td><p>(profil Accessibilité)</p>
+<td><p>(partie Accessibilité)</p>
 <p><strong>EQUIPMENT</strong></p></td>
 <td></td>
 </tr>
@@ -806,7 +784,7 @@ PASSENGER STOP ASSIGNMENT</strong></p></td>
 <td><em><strong>Trip plan computation — scheduled modes transport</strong></em></td>
 <td>Accessibility of access nodes, and paths within an interchange (such as existence of lifts, escalators)</td>
 <td><strong>STOP PLACE's FACILITIES</strong></td>
-<td><p><em>(profil Accessibilité)</em></p>
+<td><p><em>(partie Accessibilité)</em></p>
 <p><strong>EQUIPMENT<br />
 NAVIGATION PATH<br />
 </strong></p></td>
@@ -817,7 +795,7 @@ NAVIGATION PATH<br />
 <td><em><strong>Trip plan computation — scheduled modes transport</strong></em></td>
 <td>Existence of assistance services (such as existence of on-site assistance)</td>
 <td><strong>STOP PLACE's FACILITIES</strong></td>
-<td><p>(profil Accessibilité)</p>
+<td><p>(partie Accessibilité)</p>
 <p><strong>LOCAL SERVICE</strong></p></td>
 <td></td>
 </tr>
@@ -1521,7 +1499,7 @@ la façon suivante:
 <td><em>AccessibilityAssessment</em></td>
 <td>0:1</td>
 <td><p>Information globale précisant le niveau d'accessibilité du <span class="hl">LIEU D'ARRÊT, de la ZONE D'EMBARQUEMENT ou de l'ACCÈS</span>.</p>
-<p>Voir le détail ci-dessous.</p></td>
+<p>Voir le détail dans la section 'Éléments d’accessibilité de base partagés par toutes les parties du profil France' de la partie Accessibilité.</p></td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -65,23 +65,26 @@ concepts nécessaires en entrée et sortie des systèmes de planification
 de l'offre (graphiquage, etc.) et des SAE (Systèmes d’Aide à
 l’Exploitation).
 
-NeTEx se décompose en trois parties:
+NeTEx se décompose en six parties:
 
 -   Partie 1 : topologie des réseaux (les réseaux, les lignes, les
     parcours commerciaux les missions commerciales, les arrêts et lieux
     d’arrêts, les correspondances et les éléments géographiques en se
     limitant au strict minimum pour l’information voyageur)
 
-
-
 -   Partie 2 : horaires théoriques (les courses commerciales, les heures
     de passage graphiquées, les jours types associés ainsi que les
     versions des horaires)
 
-
-
 -   Partie 3 : information tarifaire (uniquement à vocation
     d’information voyageur)
+
+-   Partie 4 : profil européen pour l'information voyageur (EPIP)
+
+-   Partie 5 : nouveaux modes (les véhicules partagés en libre service, les courses partagées, etc.)
+
+-   Partie 6 : profil européen pour l'information voyageur en lien avec l'accessibilité (EPIAP)
+
 
 NeTEx a été développé dans le cadre du CEN/TC 278/WG 3/SG 9 piloté par
 la France. Les parties 1 et 2 ont été publiées en tant que spécification
@@ -149,40 +152,11 @@ des informations comme :
 
 -   etc.
 
-Les principaux profils actuellement utilisés en France sont NEPTUNE
-(profil de TRIDENT) et le profil de SIRI défini par le CEREMA et le
-STIF. Ces deux profils ont une vocation nationale.
+Ce document présente la partie Éléments communs du profil France de NeTEx, tel que défini par le Groupe de Travail dédié à l'information voyageur et à l'exploitation des services de mobilité (GT7) au sein de la Commission Nationale de normalisation pour le transport public (CN03).
 
-Il est envisagé de produire différents profils de NeTEx avec des
-objectif métiers et fonctionnels spécialisés. Il est en particulier
-prévu :
+D'autres parties du profil France de NeTEx sont disponibles (arrêts, réseau, horaire, tarif, accessibilité, parking). Ils
+sont tous complémentaires les uns des autres (sans recouvrement) et s'appuient tous sur cette partie.
 
--   un profil pour les arrêts,
-
-
-
--   un profil pour les réseaux et leur topologie,
-
-
-
--   un profil pour les horaire (distinguant horaires et calendriers),
-
-
-
--   un profil pour les tarifs,
-
-
-
--   un profil complémentaire pour les arrêts (parking, cheminements,
-    équipements, détail de l’accessibilité),
-
-Tous ces profils utiliseront toutefois tous certains concepts génériques
-mis à disposition par NeTEx (ENTITÉ, VERSION, etc.). Ce document a pour
-vocation de regrouper tous ces éléments communs afin d’en éviter de
-multiples descriptions.
-
-Ce document sera donc naturellement référencé par tous les autres
-profils.
 
 **NOTE** : Ce document étant un profil d'échange de NeTEx, il ne se substitue
 en aucun cas à NeTEx, et un minumm de connaissance de NeTEx sera
@@ -1702,62 +1676,52 @@ etc.)
 
 Les informations concernant l'ACCESSIBILITÉ sont utilisées de la même
 façon pour les LIEUx D'ARRÊT, les LIGNEs et les COURSEs. L’information
-d’accessibilité présentée correspond à une information minimale : le
-profil NeTEx pour l’accessibilité propose une version beaucoup plus
+d’accessibilité présentée correspond à une information minimale : la partie
+Accessibilité du profil France de NeTEx propose une version beaucoup plus
 détaillée de cette information (incluant les cheminements, les
 équipements, etc.).
 
-<div class="table-title">AccessibilityAssessment – Element (objet inclus)</div>
+Les ÉVALUATIONs D’ACCESSIBILITÉ (ACCESSIBILITY ASSESSMENT) retenues dans le profil Franec sont :
 
-<table>
-<colgroup>
-<col style="width: 9%" />
-<col style="width: 20%" />
-<col style="width: 20%" />
-<col style="width: 8%" />
-<col style="width: 41%" />
-</colgroup>
-<tbody>
-<tr class="odd">
-<td><strong>Classifi­cation</strong></td>
-<td><strong>Nom</strong></td>
-<td><strong>Type</strong></td>
-<td><strong>Cardinalité</strong></td>
-<td><strong>Description</strong></td>
-</tr>
-<tr class="even">
-<td>::></td>
-<td>::></td>
-<td><em>DataManagedObject</em></td>
-<td>::></td>
-<td>ACCESSIBILITY ASSESSMENT hérite de DATA MANAGED OBJECT.</td>
-</tr>
-<tr class="odd">
-<td></td>
-<td>MobilityImpaired­Access</td>
-<td><em>Accessibility­Enumeration</em></td>
-<td>1:1</td>
-<td><p>Indication globale d'accessibilité (de la LIGNE ou du LIEU).</p>
-<p>Il peut valoir <em>true</em> (accessible), <em>false</em> (non accessible), <em>partial</em> ou <em>unknown</em></p></td>
-</tr>
-<tr class="even">
-<td>«cntd»</td>
-<td>limitations</td>
-<td>AccessibilityLimitation</td>
-<td>0:1</td>
-<td>Limitations d'accessibilité</td>
-</tr>
+- *WheelchairAccess* : on peut s’y déplacer en fauteuil roulant
+- *StepFreeAccess* : on peut s’y déplacer sans franchir de marche ou d'escalier
+- *EscalatorFreeAccess* : on peut s’y déplacer sans utiliser d'escalator
+- *LiftFreeAccess* : on peut s’y déplacer sans utiliser d'ascenseur
+- *AudibleSignalsAvailable* : une information sonore ou une signalétique auditive
+ est disponible
+- *VisualSignsAvailable* : une information visuelle ou une signalétique visuelle
+ est disponible
+- *TactileGuidanceAvailable* : il y a des éléments linéaires au sol qui peuvent être détectés et suivis avec une canne, comme par exemple une bande de guidage podotactile
 
-<tr class="even">
-<td></td>
-<td><em><strong>Comment</strong></em></td>
-<td><em>MultilingualString</em></td>
-<td>0:1</td>
-<td><p>Commentaire complémentaire sur l'accessibilité.</p>
-<p><span class="hl">Ce champ a pour vocation à compléter, en termes d'information voyageur, l'information générale de la structure . Il a donc pour vocation à être affiché avec les informations d'accessibilité.</span></p></td>
-</tr>
-</tbody>
-</table>
+
+Les valeurs potentiellement portées par chacun de ces indicateurs sont:
+***Oui***, ***Non***, ***Partiel*** ou ***Inconnu***.
+
+"***Oui***" signifie que les exigences réglementaires sont remplies
+ (principalement l’arrêté du 15 janvier 2007 relatif à l’accessibilité de la voirie
+ et des espaces publics et l’arrêté du 20 avril 2017 relatif à l’accessibilité des ERPs).
+
+"***Partiel***" peut vouloir dire plusieurs choses :
+
+* partiel au niveau temporel (par exemple : pas toujours accessible
+UFR si le service d'accompagnement est limité aux jours de semaine)
+
+* partiel au niveau de l'objet/géographique (par exemple: pour une
+gare, accès possibles pour les UFR uniquement sur certains quais)
+
+* partiel par rapport à l'étendu du service (par exemple:
+signalétique auditive en cas de perturbations mais pas d'annonces pour
+les prochains passages)
+
+<span class="hl">Dans le cadre du profil il est convenu, lorsque
+"</span>***<span class="hl">Partiel</span>***<span class="hl">" est
+utilisé, de systématiquement remplir le champ "</span>***<span
+class="hl">ValidityCondition->Description</span>***<span class="hl">"
+pour préciser comment l'information doit être interprétée. Il est à noter
+que seul le champ </span>***<span class="hl">ValidityCondition</span>***
+<span class="hl"> permet de contenir une description textuelle, sous forme d'un
+texte libre susceptible d'être présenté au public en complément des
+indicateurs ci-dessus.</span>
 
 NOTE L'attribut ***MobilityImpairedAccess*** n'a pas été retenu dans le
 cadre des travaux sur le modèle d'arrêt partagé (car considéré comme

--- a/NeTEx/horaires/index.md
+++ b/NeTEx/horaires/index.md
@@ -64,23 +64,25 @@ concepts nécessaires en entrée et sortie des systèmes de planification
 de l'offre (graphiquage, etc.) et des SAE (Systèmes d’Aide à
 l’Exploitation).
 
-NeTEx se décompose en trois parties:
+NeTEx se décompose en six parties:
 
 -   Partie 1 : topologie des réseaux (les réseaux, les lignes, les
     parcours commerciaux les missions commerciales, les arrêts et lieux
     d’arrêts, les correspondances et les éléments géographiques en se
     limitant au strict minimum pour l’information voyageur)
 
-
-
 -   Partie 2 : horaires théoriques (les courses commerciales, les heures
     de passage graphiquées, les jours types associés ainsi que les
     versions des horaires)
 
-
-
 -   Partie 3 : information tarifaire (uniquement à vocation
     d’information voyageur)
+
+-   Partie 4 : profil européen pour l'information voyageur (EPIP)
+
+-   Partie 5 : nouveaux modes (les véhicules partagés en libre service, les courses partagées, etc.)
+
+-   Partie 6 : profil européen pour l'information voyageur en lien avec l'accessibilité (EPIAP)
 
 NeTEx a été développé dans le cadre du CEN/TC 278/WG 3/SG 9 piloté par
 la France. Les parties 1 et 2 ont été publiées en tant que spécification
@@ -148,20 +150,13 @@ des informations comme :
 
 -   etc.
 
-Les principaux profils actuellement utilisés en France sont NEPTUNE
-(profil de TRIDENT) et le profil de SIRI défini par le CEREMA et
-Île-de-France Mobilités. Ces deux profils ont une vocation nationale. Le
-groupe de travail GT7 (AFNOR BNTRA/CN 03/GT 7) a élaboré une sélection
-des concepts Transmodel nécessaire à la description des horaires en
-France (à vocation d'information voyageur essentiellement). C'est sur la
-base de cette sélection qu'est élaboré le présent profil.
+Ce document présente la partie Horaires du profil France de NeTEx, tel que défini par le Groupe de Travail dédié à l'information voyageur et à l'exploitation des services de mobilité (GT7) au sein de la Commission Nationale de normalisation pour le transport public (CN03).
 
-D'autre profils de NeTEx sont disponibles (arrêt, réseau, tarif). Ils
+D'autres parties du profil France de NeTEx sont disponibles (arrêts, réseau, tarif, accessibilité, parking). Ils
 sont tous complémentaires les uns des autres (sans recouvrement) et
-s'appuient tous sur un document partagé: **NeTEx - Profil Français de
-NETEx: éléments communs.** Il conviendra de se référer à ce document
-pour tous les éléments utilisés dans le présent document, et dont la
-structure n'est pas détaillée.
+s'appuient tous sur le document: **NeTEx - Profil France - Éléments communs.** Il conviendra de se référer à ce document pour tous
+les éléments utilisés dans le présent document, et dont la structure
+n'est pas détaillée.
 
 Ce profil d’échange a pour objectif de décrire et de structurer
 précisément les éléments nécessaires à une bonne information de
@@ -522,7 +517,7 @@ TEMPLATE SERVICE JOURNEY</strong></td>
 <td><em><strong>Trip plan computation — scheduled modes transport</strong></em></td>
 <td>Vehicles (low floor; wheelchair accessible.)</td>
 <td><strong>VEHICLE TYPE et FACILITIES associées</strong></td>
-<td><p><em>(profil Accessibilité)</em></p>
+<td><p><em>(partie Accessibilité)</em></p>
 <p><strong>EQUIPMENT</strong></p></td>
 <td></td>
 </tr>
@@ -864,7 +859,7 @@ autorisés à monter à bord ou à descendre du véhicule aux arrêts.
 <td colspan="2"><em><strong>facilities</strong></em></td>
 <td><em>serviceFacilitySets_RelStructure</em></td>
 <td>0:*</td>
-<td>Services disponibles pour cette course (voir le profil accessibilité pour plus de détails).</td>
+<td>Services disponibles pour cette course (voir la partie accessibilité du profil pour plus de détails).</td>
 </tr>
 <tr class="odd">
 <td></td>

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -65,23 +65,25 @@ concepts nécessaires en entrée et sortie des systèmes de planification
 de l'offre (graphiquage, etc.) et des SAE (Systèmes d’Aide à
 l’Exploitation).
 
-NeTEx se décompose en trois parties:
+NeTEx se décompose en six parties:
 
 -   Partie 1 : topologie des réseaux (les réseaux, les lignes, les
     parcours commerciaux les missions commerciales, les arrêts et lieux
     d’arrêts, les correspondances et les éléments géographiques en se
     limitant au strict minimum pour l’information voyageur)
 
-
-
 -   Partie 2 : horaires théoriques (les courses commerciales, les heures
     de passage graphiquées, les jours types associés ainsi que les
     versions des horaires)
 
-
-
 -   Partie 3 : information tarifaire (uniquement à vocation
     d’information voyageur)
+
+-   Partie 4 : profil européen pour l'information voyageur (EPIP)
+
+-   Partie 5 : nouveaux modes (les véhicules partagés en libre service, les courses partagées, etc.)
+
+-   Partie 6 : profil européen pour l'information voyageur en lien avec l'accessibilité (EPIAP)
 
 NeTEx a été développé dans le cadre du CEN/TC 278/WG 3/SG 9 piloté par
 la France. Les parties 1 et 2 ont été publiées en tant que spécification
@@ -149,23 +151,14 @@ des informations comme :
 
 -   etc.
 
-Les principaux profils actuellement utilisés en France sont NEPTUNE
-(profil de TRIDENT) et le profil de SIRI défini par le CEREMA et
-Île-de-France Mobilités. Ces deux profils ont une vocation nationale. Le
-présent document décrit le profil Français de NeTEx pour l’échange des
-données de description des réseaux de transport public.
+Ce document présente la partie Réseaux du profil France de NeTEx, tel que défini par le Groupe de Travail dédié à l'information voyageur et à l'exploitation des services de mobilité (GT7) au sein de la Commission Nationale de normalisation pour le transport public (CN03).
 
-Le groupe de travail GT7 (AFNOR BNTRA/CN03/GT7) a élaboré une sélection
-des concepts Transmodel nécessaire à la description des réseaux en
-France (à vocation d'information voyageur essentiellement). C'est sur la
-base de cette sélection qu'est élaboré le présent profil.
-
-D'autre profils de NeTEx sont disponibles (arrêt, horaire, tarif). Ils
+D'autres parties du profil France de NeTEx sont disponibles (arrêts, horaire, tarif, accessibilité, parking). Ils
 sont tous complémentaires les uns des autres (sans recouvrement) et
-s'appuient tous sur un document partagé: **NeTEx - Profil Français de
-NETEx: éléments communs.** Il conviendra de se référer à ce document
-pour tous les éléments utilisés dans le présent document, et dont la
-structure n'est pas détaillée.
+s'appuient tous sur le document: **NeTEx - Profil France - Éléments communs.** Il conviendra de se référer à ce document pour tous
+les éléments utilisés dans le présent document, et dont la structure
+n'est pas détaillée.
+
 
 Ce profil d’échange a pour objectif de décrire et de structurer
 précisément les éléments nécessaires à une bonne information de
@@ -728,7 +721,7 @@ ACCESS RIGHT PARAMETER ASSIGNMENT</strong></p></td>
 CONNECTION</strong> <em>et</em> <strong>SITE CONNECTION<br />
 </strong></p>
 <p><strong>ROUTE LINK</strong> <em>(donc ROUTE)</em> <em>ou</em> <strong>SERVICE LINK</strong> <em>en alternative</em></p></td>
-<td><p><em>(profil accessibilité)</em></p>
+<td><p><em>(partie accessibilité)</em></p>
 <p><strong>NAVIGATION PATH</strong></p></td>
 <td>Les SERVICE LINKs ou ROUTE LINKs impliquent naturellement les POINTs (POINT IN JOURNEY PATTERN, ROUTE POINT, POINT ON ROUTE, etc.) correspondant. Ils permettront d’évaluer la distance parcourue par le véhicule.</td>
 </tr>
@@ -1065,7 +1058,7 @@ de nuit, etc.).
 <td colspan="2"><em><strong>Accessibility­Assessment</strong></em></td>
 <td><em>Accessibility­Assessment</em></td>
 <td>0:1</td>
-<td>Information concernant l'accessibilité de la ligne <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">).</span></td>
+<td>Information concernant l'accessibilité de la ligne <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong>, ainsi que la partie Accessibilité du profil France</em><span class="hl">).</span></td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
@@ -2634,7 +2627,7 @@ D'EMBARQUEMENT (QUAY).
 <td><em>navigationPaths</em></td>
 <td>0:1</td>
 <td><p>Description du cheminement utilisé pour cette correspondance.</p>
-<p><span class="hl">Dans le cadre du Profil Réseau, le NAVIGATION PATH n'est utilisé que pour indiquer de façon générale les contraintes d'accessibilité du cheminement (champs AccessFeatureList et NavigationType). La description complète et détaillée du NAVIGATION PATH n'interviendra que dans un profil dédié.</span></p></td>
+<p><span class="hl">Dans le cadre du Profil Réseau, le NAVIGATION PATH n'est utilisé que pour indiquer de façon générale les contraintes d'accessibilité du cheminement (champs AccessFeatureList et NavigationType). La description complète et détaillée du NAVIGATION PATH est dans la partie Accessibilité du profil France.</span></p></td>
 </tr>
 </tbody>
 </table>
@@ -2856,7 +2849,7 @@ type d’objet OSM pour garantir l’unicité de l’identifiant)</span>
 La description du cheminement est ici limitée à ses caractéristiques
 principales (en particulier pour l'accessibilité).
 
-<span class="hl">Note : le profil NeTEx pour l’accessibilité fournit
+<span class="hl">Note : la partie Accessibilité du profil France fournit
 une vue beaucoup plus détaillée du NavigationPath.</span>
 
 <div class="table-title">NavigationPath – Element</div>

--- a/NeTEx/tarifs/index.md
+++ b/NeTEx/tarifs/index.md
@@ -62,25 +62,25 @@ concepts nécessaires en entrée et sortie des systèmes de planification
 de l'offre (graphiquage, etc.) et des SAE (Systèmes d’Aide à
 l’Exploitation).
 
-NeTEx se décompose en cinq parties :
+NeTEx se décompose en six parties:
 
-- Partie 1 : topologie des réseaux (les réseaux, les lignes, les
-  parcours commerciaux les missions commerciales, les arrêts et lieux
-  d’arrêts, les correspondances et les éléments géographiques en se
-  limitant au strict minimum pour l’information voyageur)
+-   Partie 1 : topologie des réseaux (les réseaux, les lignes, les
+    parcours commerciaux les missions commerciales, les arrêts et lieux
+    d’arrêts, les correspondances et les éléments géographiques en se
+    limitant au strict minimum pour l’information voyageur)
 
-- Partie 2 : horaires théoriques (les courses commerciales, les heures
-  de passage graphiquées, les jours types associés ainsi que les
-  versions des horaires)
+-   Partie 2 : horaires théoriques (les courses commerciales, les heures
+    de passage graphiquées, les jours types associés ainsi que les
+    versions des horaires)
 
-- Partie 3 : information tarifaire (uniquement à vocation d’information
-  voyageur)
+-   Partie 3 : information tarifaire (uniquement à vocation
+    d’information voyageur)
 
-- Partie 4 : Profil Européen pour l’information voyageur (EPIP :
-  European Passenger Information Profile)
+-   Partie 4 : profil européen pour l'information voyageur (EPIP)
 
-- Partie 5 : NeTEx New Modes extension (vehicle sharing, vehicle
-  pooling, etc.)
+-   Partie 5 : nouveaux modes (les véhicules partagés en libre service, les courses partagées, etc.)
+
+-   Partie 6 : profil européen pour l'information voyageur en lien avec l'accessibilité (EPIAP)
 
 NeTEx a été développé dans le cadre du CEN/TC 278/WG 3/SG 9 piloté par
 la France. Les parties 1 et 2 ont été publiées en tant que spécification
@@ -138,21 +138,14 @@ des informations comme :
 
 - etc.
 
-Les principaux profils actuellement utilisés en France sont NEPTUNE
-(profil de TRIDENT) et le profil de SIRI défini par le CEREMA et
-Île-de-France Mobilités (un profil SIRI Frane, qui en découle, est en
-cours d’élaboration). Ces deux profils ont une vocation nationale. Le
-groupe de travail GT7 (AFNOR BNTRA/CN 03/GT 7) a élaboré une sélection
-des concepts Transmodel nécessaire à la description des horaires en
-France (à vocation d'information voyageur essentiellement). C'est sur la
-base de cette sélection qu'est élaboré le présent profil.
+Ce document présente la partie Tarifs du profil France de NeTEx, tel que défini par le Groupe de Travail dédié à l'information voyageur et à l'exploitation des services de mobilité (GT7) au sein de la Commission Nationale de normalisation pour le transport public (CN03).
 
-D'autre profils de NeTEx sont disponibles (arrêt, réseau, horaire). Ils
+D'autres parties du profil France de NeTEx sont disponibles (arrêts, réseau, horaire, accessibilité, parking). Ils
 sont tous complémentaires les uns des autres (sans recouvrement) et
-s'appuient tous sur un document partagé: **NeTEx - Profil Français de
-NETEx: éléments communs.** Il conviendra de se référer à ce document
-pour tous les éléments utilisés dans le présent document, et dont la
-structure n'est pas détaillée.
+s'appuient tous sur le document: **NeTEx - Profil France - Éléments communs.** Il conviendra de se référer à ce document pour tous
+les éléments utilisés dans le présent document, et dont la structure
+n'est pas détaillée.
+
 
 Ce profil d’échange a pour objectif de décrire et de structurer
 précisément les éléments nécessaires à une bonne information de


### PR DESCRIPTION
Changements de toutes les parties du profil France pour : 
- mettre à jour les parties de NeTEx
- reprendre la sémantique du profil France unifié
- renvoyer vers la partie Accessibilité sur tous les objets contenant un ACCESSIBILITY ASSESMENT et/ou sur des objets détaillés dans cette partie-là (ex. NAVIGATION PATH)