### PR TITLE
Reseaux - Précision sur RoutingConstraintZone

### DIFF
--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -3033,6 +3033,13 @@ description des ITL (Interdiction de trafic local).
 <td>0:1</td>
 <td>Groupe de lignes ou réseau concerné par la restriction</td>
 </tr>
+<tr class="even">
+<td></td>
+<td><em><strong>pointsInPattern</strong></em></td>
+<td><em>pointsInPattern</em></td>
+<td></td>
+<td><span class="hl">Cette propriété n'est pas retenue dans le profil France. Le champ <em>member</em> est utilisé, comme indiqué ci-dessus dans l'héritage de Zone.</span></td>
+</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
Proposition pour expliciter que `pointsInJourneyPattern` n'est pas retenu dans le profil France.
(issue https://github.com/etalab/transport-profil-netex-fr/issues/233 )