### PR TITLE
ElementsCommuns - Correction de LinkSequence

### DIFF
--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -1457,7 +1457,8 @@ d'objets plus complexes comme les ITINÉRAIREs (voir Profil Réseau).
 |---------------------|----------------|----------------------|------------------|-------------------------------------------------------|
 | ::>                 | ::>            | *DataManagedObject*  | ::>              | LINK SEQUENCE hérite de ***DataManagedObject***.      |
 |                     | ***Name***     | *MultilingualString* | 0:1              | Nom de la SÉQUENCE DE TRONÇON.                        |
-|                     | ***Distance*** | *DistanceType*       | 1:1              | Longueur totale (en mètre) de la SÉQUENCE DE TRONÇON. |
+|                     | ***Distance*** | *DistanceType*       | 0:1              | Longueur totale (en mètre) de la SÉQUENCE DE TRONÇON. |
+|                     | ***sectionsInSequence*** | *SectionInSequence*       | 0:*              | Liste de TRONÇON. |
 
 ## Attributs des Points d’une Séquence de Tronçons
 

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -1458,7 +1458,7 @@ d'objets plus complexes comme les ITINÉRAIREs (voir Profil Réseau).
 | ::>                 | ::>            | *DataManagedObject*  | ::>              | LINK SEQUENCE hérite de ***DataManagedObject***.      |
 |                     | ***Name***     | *MultilingualString* | 0:1              | Nom de la SÉQUENCE DE TRONÇON.                        |
 |                     | ***Distance*** | *DistanceType*       | 0:1              | Longueur totale (en mètre) de la SÉQUENCE DE TRONÇON. |
-|                     | ***sectionsInSequence*** | *SectionInSequence*       | 0:*              | Liste de TRONÇON. |
+|                     | ***sectionsInSequence*** | *SectionInSequence*       | 0:*              | Liste ordonnée de TRONÇONs. |
 
 ## Attributs des Points d’une Séquence de Tronçons
 


### PR DESCRIPTION
Réponse à l'issue https://github.com/etalab/transport-profil-netex-fr/issues/53
En vérifiant sur NeTEx sur `main` et `next`, la propriété Distance est bien optionnelle. La PR corrige la cardinalité, et ajoute la propriété qui permet de lister les tronçons.
