### PR TITLE
Ajout de la nouvelle structure des Frame (partie 1)

### DIFF
--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -3949,6 +3949,50 @@ CALENDRIER** et **NeTEx TARIF***.
 <span class="hl">Dans le cadre du profil les distances et les longueurs sont par défaut
 exprimées en mètres (*SystemOfUnits* ayant une valeur *SiMetres*) et les sommes d’argent en Euros.</span>
 
+<div class="table-title">TypeOfFrame – Element</div>
+
+<table>
+<colgroup>
+<col style="width: 9%" />
+<col style="width: 17%" />
+<col style="width: 19%" />
+<col style="width: 12%" />
+<col style="width: 41%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><strong>Classifi­cation</strong></th>
+<th><strong>Nom</strong></th>
+<th><strong>Type</strong></th>
+<th></th>
+<th><strong>Description</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>::></td>
+<td>::></td>
+<td><em>TypeOfValueDataManagedObject</em></td>
+<td><em>::>::></em></td>
+<td><p>TYPE OF FRAME hérite de TYPE OF VALUE.</p>
+<p><span class="hl">L'Id est imposé à NETEX_</span><span class="hl"> </span><span class="hl">RESEAU</span></p></td>
+</tr>
+
+
+<tr class="even">
+<td>«cntd»</td>
+<td><em><strong>classes</strong></em></td>
+<td><em>ClassInContextRef</em></td>
+<td>0:*</td>
+<td><p>Liste des classes pouvant être contenu dans ce TYPE OF FRAME.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+Chaque partie du profil France décrit les frames associées et la valeur spécifique du type de Frame a utiliser, et 
+le chapitre 7.4 du présent document rappelle les différentes valeurs.
+
 ## CODESPACE et codification des identifiants
 
 NeTEx propose un mécanisme de CODESPACE (à mettre en parallèle avec les
@@ -4208,9 +4252,104 @@ le cadre d’un échange et que l’identifiant utilisé et unique au niveau
 national et pérenne, on conservera naturellement son identifiant et la
 codification ci-dessus ne s’applique plus.</span>
 
-## TypeOfFrame : types spécifiques
+## TypeOfFrame : types spécifiques 
 
-Le présent profil utilise un *TypeOfFrame* spécifique, identifié
+
+Le présent profil utilise des valeurs précises de *TypeOfFrame* pour spécifier le contenu de chaque fichier : 
+- accessibility.xml : TypeOfFrame NETEX_ACCESSIBILITY, décrit dans la partie accessibilité du profil
+- network.xml : TypeOfFrame NETEX_RESEAU décrit dans la partie "Description du réseau" du profil
+- stop.xml : TypeOfFrame NETEX_ARRET, décrit dans la partie "Description des arrêts" du profil
+- line_xyz.xml : TypeOfFrame NETEX_LIGNE et NETEX_LIGNE_STRUCTURE dans la partie "Description des réseaux" et NETEX_HORAIRE dans la partie Horaires du profil
+- fare.xml : TypeOfFrame NETEX_TARIF dans la partie Tarifs du profil
+- parking.xml : A venir dans la partie Parking du profil
+- poi.xml : TypeOfFrame NETEX_POI dans la partie décrits dans la partie Elements Communs du profil
+- resource.xml : TypeOfFrame NETEX_FRANCE, NETEX_COMMUN et NETEX_CALENDRIER décrits dans la partie Elements Communs du profil
+
+Attention : les identifiants sont construits selon les recommandations du présent profil. Par exemple, `NETEX_LIGNE` sera présent dans un fichier
+avec la valeur complète `FR:TypeOfFrame:NETEX_LIGNE:`.
+
+Le fichier `resource.xml` contient une CompositeFrame de type `NETEX_FRANCE`, elle-même composée de :
+- Une GeneralFrame de type `NETEX_COMMUN`
+- Une GeneralFrame de type `NETEX_CALENDRIER`
+Les objets de premiers niveaux possibles dans ces frames sont indiqués dans les exemples XML ci-dessous sous forme de commentaires.
+
+Le fichier `poi.xml` contient une GeneralFrame de type `NETEX_POI`.
+
+Voici un exemple de cadre du fichier `resource.xml` :
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.09:FR-NETEX-2.1-1.0">
+  <PublicationTimestamp>2023-01-01T00:00:00.0Z</PublicationTimestamp>
+  <ParticipantRef>Exemple</ParticipantRef>
+  <dataObjects>
+    <CompositeFrame id="exemple:CompositeFrame:NETEX_FRANCE-1:LOC" version="1.09:FR-NETEX-2.1-1.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_FRANCE:" />
+      <frames>
+        <GeneralFrame id="exemple:GeneralFrame:NETEX_COMMUN-1:LOC" version="1.09:FR-NETEX-2.1-1.0">
+          <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_COMMUN:" />
+          <members>
+            <!--
+              VALIDITY CONDITION (AVAILABILITY CONDITION et VALIDITY TRIGGER)
+              ALTERNATIVE NAME
+              NOTICE
+              NOTICE ASSIGNMENT
+              RESPONSIBILITY ROLE ASSIGNMENT
+              ORGANISATION
+              POINT PROJECTION
+              ZONE PROJECTION
+              TYPE OF VALUE spécifiques
+              DATA SOURCE
+              SITE CONNECTION
+              VEHICLE TYPE
+              CONNECTION 
+              JOURNEY INTERCHANGE
+              DEFAULT CONNECTION
+              BOOKING ARRANGEMENT
+              SERVICE FACILITY SET
+              -->
+          </members>
+        </GeneralFrame>
+        <GeneralFrame id="exemple:GeneralFrame:NETEX_CALENDRIER-1:LOC" version="1.09:FR-NETEX-2.1-1.0">
+          <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_CALENDRIER:" />
+          <members>
+            <!--
+              DAY TYPE
+              OPERATING PERIOD
+              SERVICE CALENDAR
+              DAY TYPE ASSIGNMENT
+              -->
+          </members>
+        </GeneralFrame>
+      </frames>
+    </CompositeFrame>
+  </dataObjects>
+</PublicationDelivery>
+```
+
+Voici un exemple de cadre du fichier `poi.xml` :
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.09:FR-NETEX-2.1-1.0">
+  <PublicationTimestamp>2023-01-01T00:00:00.0Z</PublicationTimestamp>
+  <ParticipantRef>Exemple</ParticipantRef>
+  <dataObjects>
+    <GeneralFrame id="exemple:GeneralFrame:NETEX_POI-1:LOC" version="1.09:FR-NETEX-2.1-1.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_POI:" />
+      <members>
+        <!--
+          POINT OF INTEREST
+          POINT OF INTEREST CLASSIFICATION
+          POINT OF INTEREST ENTRANCE
+          -->
+      </members>
+    </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>
+```
+
+ spécifique, identifié
 ***<span class="hl">NETEX_COMMUN, NETEX_ARRET</span>, <span
 class="hl">NETEX_RESEAU, NETEX_HORAIRE, NETEX_CALENDRIER,
 NETEX_TARIF</span>***. Il apparaitra systématiquement et explicitement

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -3949,7 +3949,7 @@ CALENDRIER** et **NeTEx TARIF***.
 <span class="hl">Dans le cadre du profil les distances et les longueurs sont par défaut
 exprimées en mètres (*SystemOfUnits* ayant une valeur *SiMetres*) et les sommes d’argent en Euros.</span>
 
-<div class="table-title">TypeOfFrame – Element</div>
+<div class="table-title">TypeOfFrame – Élément</div>
 
 <table>
 <colgroup>
@@ -3984,13 +3984,13 @@ exprimées en mètres (*SystemOfUnits* ayant une valeur *SiMetres*) et les somme
 <td><em><strong>classes</strong></em></td>
 <td><em>ClassInContextRef</em></td>
 <td>0:*</td>
-<td><p>Liste des classes pouvant être contenu dans ce TYPE OF FRAME.</p>
+<td><p>Liste des classes pouvant être contenues dans ce TYPE OF FRAME.</p>
 </td>
 </tr>
 </tbody>
 </table>
 
-Chaque partie du profil France décrit les frames associées et la valeur spécifique du type de Frame a utiliser, et 
+Chaque partie du profil France décrit les frames associées et la valeur spécifique du type de Frame à utiliser, et 
 le chapitre 7.4 du présent document rappelle les différentes valeurs.
 
 ## CODESPACE et codification des identifiants
@@ -4261,9 +4261,9 @@ Le présent profil utilise des valeurs précises de *TypeOfFrame* pour spécifie
 - stop.xml : TypeOfFrame NETEX_ARRET, décrit dans la partie "Description des arrêts" du profil
 - line_xyz.xml : TypeOfFrame NETEX_LIGNE et NETEX_LIGNE_STRUCTURE dans la partie "Description des réseaux" et NETEX_HORAIRE dans la partie Horaires du profil
 - fare.xml : TypeOfFrame NETEX_TARIF dans la partie Tarifs du profil
-- parking.xml : A venir dans la partie Parking du profil
-- poi.xml : TypeOfFrame NETEX_POI dans la partie décrits dans la partie Elements Communs du profil
-- resource.xml : TypeOfFrame NETEX_FRANCE, NETEX_COMMUN et NETEX_CALENDRIER décrits dans la partie Elements Communs du profil
+- parking.xml : À venir dans la partie Parking du profil
+- poi.xml : TypeOfFrame NETEX_POI, décrit dans la partie Éléments Communs du profil
+- resource.xml : TypeOfFrame NETEX_FRANCE, NETEX_COMMUN et NETEX_CALENDRIER décrits dans la partie Éléments Communs du profil
 
 Attention : les identifiants sont construits selon les recommandations du présent profil. Par exemple, `NETEX_LIGNE` sera présent dans un fichier
 avec la valeur complète `FR:TypeOfFrame:NETEX_LIGNE:`.
@@ -4279,14 +4279,14 @@ Voici un exemple de cadre du fichier `resource.xml` :
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.09:FR-NETEX-2.1-1.0">
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="2.0:FR-NETEX-2.4">
   <PublicationTimestamp>2023-01-01T00:00:00.0Z</PublicationTimestamp>
   <ParticipantRef>Exemple</ParticipantRef>
   <dataObjects>
-    <CompositeFrame id="exemple:CompositeFrame:NETEX_FRANCE-1:LOC" version="1.09:FR-NETEX-2.1-1.0">
+    <CompositeFrame id="exemple:CompositeFrame:NETEX_FRANCE-1:LOC" version="2.0:FR-NETEX-2.4">
       <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_FRANCE:" />
       <frames>
-        <GeneralFrame id="exemple:GeneralFrame:NETEX_COMMUN-1:LOC" version="1.09:FR-NETEX-2.1-1.0">
+        <GeneralFrame id="exemple:GeneralFrame:NETEX_COMMUN-1:LOC" version="2.0:FR-NETEX-2.4">
           <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_COMMUN:" />
           <members>
             <!--
@@ -4310,7 +4310,7 @@ Voici un exemple de cadre du fichier `resource.xml` :
               -->
           </members>
         </GeneralFrame>
-        <GeneralFrame id="exemple:GeneralFrame:NETEX_CALENDRIER-1:LOC" version="1.09:FR-NETEX-2.1-1.0">
+        <GeneralFrame id="exemple:GeneralFrame:NETEX_CALENDRIER-1:LOC" version="2.0:FR-NETEX-2.4">
           <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_CALENDRIER:" />
           <members>
             <!--
@@ -4331,11 +4331,11 @@ Voici un exemple de cadre du fichier `poi.xml` :
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.09:FR-NETEX-2.1-1.0">
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="2.0:FR-NETEX-2.4">
   <PublicationTimestamp>2023-01-01T00:00:00.0Z</PublicationTimestamp>
   <ParticipantRef>Exemple</ParticipantRef>
   <dataObjects>
-    <GeneralFrame id="exemple:GeneralFrame:NETEX_POI-1:LOC" version="1.09:FR-NETEX-2.1-1.0">
+    <GeneralFrame id="exemple:GeneralFrame:NETEX_POI-1:LOC" version="2.0:FR-NETEX-2.4">
       <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_POI:" />
       <members>
         <!--
@@ -4349,239 +4349,7 @@ Voici un exemple de cadre du fichier `poi.xml` :
 </PublicationDelivery>
 ```
 
- spécifique, identifié
-***<span class="hl">NETEX_COMMUN, NETEX_ARRET</span>, <span
-class="hl">NETEX_RESEAU, NETEX_HORAIRE, NETEX_CALENDRIER,
-NETEX_TARIF</span>***. Il apparaitra systématiquement et explicitement
-dans les éléments ***members*** du ***GeneralFrame***.
-
-Le présent document ne présente que les *TypeOfFrame* ***<span
-class="hl">NETEX_COMMUN</span>** et **<span
-class="hl">NETEX_CALENDRIER</span>***. Les autres seront présentés par
-les documents spécifiques de chacun des profils.
-
-Dans la majorité des cas on aura besoin de plusieurs CADREs DE VERSION
-pour un échange complet (par exemple ***<span
-class="hl">NETEX_COMMUN</span>** et **<span
-class="hl">NETEX_ARRET</span>***): on utilisera donc un
-***CompositeFrame*** pour les grouper au sein d'un unique échange.
-
-Trois types spécifiques sont attribués à ces ***CompositeFrame**:*
-
--   ***<span class="hl">NETEX_FRANCE</span>*** peut contenir n'importe
-    quelles autres Frames et n'importe quel jeu de données
-
--   ***<span class="hl">NETEX_LIGNE</span>*** contient des
-    ***GeneralFrame*** de type ***<span class="hl">NETEX_COMMUN</span>, 
-    <span class="hl">NETEX_RESEAU, NETEX_HORAIRE</span>** et **<span
-    class="hl">NETEX_CALENDRIER</span>*** permettant la description
-    complète d'une unique ligne (une et une seule, avec toutes les
-    informations nécessaires à l'information voyageur). Le champ
-    ***Name*** des ***CompositeFrame*** de type ***<span
-    class="hl">NETEX_LIGNE</span>*** contient le nom de la ligne.
-
--   ***<span class="hl">NETEX_N\_LIGNES</span>*** contient des
-    ***GeneralFrame*** de type ***<span class="hl">NETEX_COMMUN</span>, 
-    <span class="hl">NETEX_RESEAU, NETEX_HORAIRE</span>** et **<span
-    class="hl">NETEX_CALENDRIER</span>*** permettant la description
-    complète d'un ensemble de lignes (toutes les informations
-    nécessaires à l'information voyageur pour les lignes concernées). Le
-    champ ***Name*** des ***CompositeFrame*** de type ***<span
-    class="hl">NETEX_N\_LIGNE</span>*** contient le nom des lignes
-    concernées, séparés par des virgules.
-
-<div class="table-title">TypeOfFrame pour NETEX_COMMUN et NETEX_CALENDRIER – Element (objet inclus)</div>
-
-<table>
-<colgroup>
-<col style="width: 9%" />
-<col style="width: 17%" />
-<col style="width: 19%" />
-<col style="width: 12%" />
-<col style="width: 41%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Classifi­cation</strong></th>
-<th><strong>Nom</strong></th>
-<th><strong>Type</strong></th>
-<th></th>
-<th><strong>Description</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>::></td>
-<td>::></td>
-<td><em>TypeOfValueDataManagedObject</em></td>
-<td><em>::></em></td>
-<td><p>TYPE OF FRAME hérite de TYPE OF VALUE.</p>
-<p><span class="hl">L'Id est imposé à </span><em><span class="hl">NETEX_COMMUN</span></em><span class="hl"> </span><span class="hl">ou </span><em><span class="hl">NETEX_CALENDRIER</span></em></p></td>
-</tr>
-
-
-<tr class="even">
-<td>«cntd»</td>
-<td><em><strong>classes</strong></em></td>
-<td><em>ClassInContextRef</em></td>
-<td>0:*</td>
-<td><p>Liste des classes pouvant être contenues dans ce TYPE OF FRAME.</p>
-<p><span class="hl">La liste est fixe pour NETEX_COMMUN:</span></p>
-<ul>
-<li><p><span class="hl">VALIDITY CONDITION (AVAILABILITY CONDITION et VALIDITY TRIGGER)</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">ALTERNATIVE NAME</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">NOTICE</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">NOTICE ASSIGNMENT</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">RESPONSIBILITY ROLE ASSIGNMENT</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">ORGANISATION</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">POINT PROJECTION</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">ZONE PROJECTION</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">TYPE OF FRAME</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">TYPE OF VALUE spécifiques</span></p></li>
-</ul>
-<p><span class="hl">La liste est fixe pour NETEX_CALENDRIER:</span></p>
-<ul>
-<li><p><span class="hl">DAY TYPE</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">OPERATING DAY</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">SERVICE CALENDAR</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">DAY TYPE ASSIGNMENT</span></p></li>
-</ul></td>
-</tr>
-</tbody>
-</table>
-
-<div class="table-title">TypeOfFrame pour NETEX_FRANCE, NETEX_LIGNE et NETEX_N_LIGNES – Element (objet inclus) </div>
-
-<table>
-<colgroup>
-<col style="width: 9%" />
-<col style="width: 17%" />
-<col style="width: 19%" />
-<col style="width: 12%" />
-<col style="width: 41%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Classifi­cation</strong></th>
-<th><strong>Nom</strong></th>
-<th><strong>Type</strong></th>
-<th></th>
-<th><strong>Description</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>::></td>
-<td>::></td>
-<td><em>TypeOfValueDataManagedObject</em></td>
-<td><em>::></em></td>
-<td><p>TYPE OF FRAME hérite de TYPE OF VALUE.</p>
-<p><span class="hl">L'Id est imposé à </span><em><span class="hl">NETEX_FRANCE, NETEX_LIGNE ou NETEX_N_LIGNES</span></em></p></td>
-</tr>
-<tr class="odd">
-<td>FK</td>
-<td><em><strong>typesOfFrame</strong></em></td>
-<td><em>TypeOfFrameRef</em></td>
-<td>0:*</td>
-<td><p>TYPES OF FRAME contenu dans ce TYPE OF FRAME. Ne dois pas être récursif.</p>
-<p>On trouve ici les TYPES OF FRAME autorisés au sein de la <em><strong>CompositeFrame</strong></em> <em><span class="hl">NETEX_FRANCE</span></em>, à savoir:</p>
-<ul>
-<li><p><span class="hl">NETEX_COMMUN, </span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">NETEX_ARRET, </span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">NETEX_RESEAU, </span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">NETEX_HORAIRE,</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">NETEX_CALENDRIER, </span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">NETEX_TARIF</span></p></li>
-</ul></td>
-</tr>
-</tbody>
-</table>
-
-<div class="table-title">TypeOfValue (pour le TypeOfFrame) – Element (objet inclus) </div>
-
-<table>
-<colgroup>
-<col style="width: 9%" />
-<col style="width: 17%" />
-<col style="width: 19%" />
-<col style="width: 12%" />
-<col style="width: 41%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Classifi­cation</strong></th>
-<th><strong>Nom</strong></th>
-<th><strong>Type</strong></th>
-<th></th>
-<th><strong>Description</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>::></td>
-<td>::></td>
-<td><em>DataManagedObject</em></td>
-<td>::></td>
-<td><p>TYPE OF VALUE hérite de DATA MANAGED OBJECT.</p>
-<p><span class="hl">L’attribut version portera la version du profil.</span></p>
-<p><span class="hl">L'Identifiant du TYPE OF VALUE est imposé à NETEX_COMMUN ou NETEX_CALENDRIER ou NETEX_FRANCE, NETEX_LIGNE ou NETEX_N_LIGNES</span></p></td>
-</tr>
-<tr class="even">
-<td></td>
-<td><em><strong>Name</strong></em></td>
-<td><em>MultilingualString</em></td>
-<td>1:1</td>
-<td><p>Nom du TYPE OF VALUE.</p>
-<p><span class="hl">Imposé à « NETEX_COMMUN», « NETEX_CALENDRIER» ou « NETEX_FRANCE», «NETEX_LIGNE» ou «NETEX_N_LIGNES»</span></p></td>
-</tr>
-
-<tr class="even">
-<td></td>
-<td><em><strong>Description</strong></em></td>
-<td><em>MultilingualString</em></td>
-<td>1:1</td>
-<td><p>Description du TYPE OF VALUE.</p>
-<p><span class="hl">Imposé à « Profil d’échange français NETEX_COMMUN», « Profil d’échange français NETEX_CALENDRIER». Ou « Profil d’échange français «NETEX_FRANCE», «NETEX_LIGNE» ou «NETEX_N_LIGNES».</span></p></td>
-</tr>
-
-
-
-</tbody>
-</table>
+ 
 
 ## Version des objets et références
 

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -3389,368 +3389,144 @@ de du ministère des transport) et les POINTs D'ARRÊT PLANIFIÉs.
 # Entêtes NeTEx
 
 *Note: les entêtes NeTEx sont présentés dans le document éléments
-communs. Seules les spécificités du profil NETEX_RESEAU sont présentées
+communs. Seules les spécificités de la partie "description du réseau" sont présentées
 ici.*
 
-Deux FRAMEs distincts peuvent être utilisés pour échanger la description
-des réseaux: l'un pour n'échanger qu'une description de haut niveau des
-lignes (**NETEX_LIGNE**) et l'autre pour échanger l'ensemble de la
-description du réseau (**NETEX_RESEAU**). Le FRAME **NETEX_RESEAU** peut
-naturellement contenir le FRAME **NETEX_LIGNE**.
+Deux FRAMEs distincts sont utilisées pour échanger la description des réseaux : 
+- Une FRAME de type **NETEX_RESEAU**, utilisée dans le fichier "network.xml" 
+- Une FRAME de type **NETEX_LIGNE**, utilisée dans le fichier "line_xyz.xml" 
+  l'un pour n'échanger qu'une description de haut niveau des
 
-## TypeOfFrame : type spécifique *NETEX_LIGNE*
+Pour rappel, la liste des fichiers d'un export NeTEx profil France est décrite dans Elements Communs.
 
-Le présent profil utilise un *TypeOfFrame* spécifique, identifié
-***NETEX_LIGNE***
+## TypeOfFrame : type spécifique *NETEX_RESEAU*
 
-<div class="table-title">TypeOfFrame – Element (objet inclus)</div>
+Le losqu'une FRAME a pour TypeOfFrame la valeur `NETEX_RESEAU`, seules les objets de premier niveau suivants sont autorisés : 
+- Network
+- GroupOfLines
+- RoutingContraintZone
 
-<table>
-<colgroup>
-<col style="width: 9%" />
-<col style="width: 17%" />
-<col style="width: 19%" />
-<col style="width: 12%" />
-<col style="width: 41%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Classifi­cation</strong></th>
-<th><strong>Nom</strong></th>
-<th><strong>Type</strong></th>
-<th></th>
-<th><strong>Description</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>::></td>
-<td>::></td>
-<td><em>TypeOfValueDataManagedObject</em></td>
-<td><em>::>::></em></td>
-<td><p>TYPE OF FRAME hérite de TYPE OF VALUE.</p>
-<p><span class="hl">L'Id est imposé à NETEX_</span><span class="hl"> </span><span class="hl">LIGNE</span></p></td>
-</tr>
+Voici un exemple de cadre du fichier `network.xml` :
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.09:FR-NETEX-2.1-1.0">
+  <PublicationTimestamp>2025-02-27T00:00:00.0Z</PublicationTimestamp>
+  <ParticipantRef>Exemple</ParticipantRef>
+  <dataObjects>
+    <GeneralFrame id="exemple:GeneralFrame:NETEX_RESEAU_1" version="1.09:FR-NETEX-2.1-1.0">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_RESEAU:" />
+      <members>
+        <!--
+          NETWORK
+          GROUP OF LINES
+          ROUTING CONSTRAINT ZONE
+          -->
+      </members>
+    </GeneralFrame>
+  </dataObjects>                  
+</PublicationDelivery>
+```
 
+## TypeOfFrame : type spécifique *NETEX_LINE* et *NETEX_LIGNE_STRUCTURE*
 
-<tr class="even">
-<td>«cntd»</td>
-<td><em><strong>classes</strong></em></td>
-<td><em>ClassInContextRef</em></td>
-<td>0:*</td>
-<td><p>Liste des classes pouvant être contenu dans ce TYPE OF FRAME.</p>
-<p><span class="hl">La liste est fixe pour NETEX_ RESEAU:</span></p>
-<ul>
-<li><p><span class="hl">LINE</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">DIRECTION</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">GROUP OF LINE</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">NETWORK</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">ROUTE</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">ROUTE POINT</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">POINT ON ROUTE</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">ROUTE LINK</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">GROUPE OF ENTITIES (sous ligne)</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">FLEXIBLE LINE</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">FLEXIBLE ROUTE</span></p></li>
-</ul></td>
-</tr>
+Le losqu'une FRAME a pour TypeOfFrame la valeur `NETEX_LINE`, il s'agit un objet `CompositeFrame`, lui-même composé de :
+- Une GeneralFrame de type `NETEX_LIGNE_STRUCTURE` (voir ci-dessous)
+- Une GeneralFrame de type `NETEX_HORAIRE`, décrit dans la partie Horaires du profil
 
+La Frame de type `NETEX_LIGNE_STRUCTURE` ne contient que les objets de premier niveau suivants (et les objets qui en héritent) : 
+- Pour la partie de description générale des lignes
+  - Line
+  - Direction
+  - Route
+  - RoutePoint
+  - PointOnRoute
+  - RouteLink
+  - FlexibleLine
+  - FlexibleRoute
+  - Route
+- Pour la partie plus précise de la ligne : 
+  - DestinationDisplay
+  - FlexiblePointProperties
+  - ServiceJourneyPattern
+  - PointInJourneyPattern
+  - ScheduledStopPoint
+  - TimingPoint
+  - TransferRestriction
+  - PassengerStopAssignement
+  - FlexibleStopAssignment
+  - TrainStopAssignment
+  - SchematicMap
 
-</tbody>
-</table>
+Voici un exemple de cadre du fichier `line_xyz.xml` :
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.09:FR-NETEX-2.1-1.0">
+  <PublicationTimestamp>2023-01-01T00:00:00.0Z</PublicationTimestamp>
+  <ParticipantRef>Exemple</ParticipantRef>
+  <dataObjects>
+    <CompositeFrame id="FR:CompositeFrame:NETEX_LIGNE-line_xyz:LOC" version="any">
+      <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_LIGNE:" />
+      <frames>
+        <GeneralFrame id="FR:GeneralFrame:NETEX_RESEAU-line_xyz:LOC" version="1.09:FR-NETEX-2.1-1.0">
+          <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_LIGNE_STRUCTURE:" />
+          <members>
+            <Line id="sample" version="any">
+              <Name>Ligne d'exemple</Name>
+            </Line>
+            <!--  Partie Ligne
+              Peut contenir (chaque objet contiendra ses objets sous-jacents, les éléments listés ici pourront être référencés dans les autres objets)
+              LINE 
+              DIRECTION
+              ROUTE
+              ROUTE POINT
+              POINT ON ROUTE
+              ROUTE LINK
+              FLEXIBLE LINE
+              FLEXIBLE ROUTE
+            -->
 
-<div class="table-title">TypeOfValue (pour le TypeOfFrame NETEX\_ LIGNE) – Element</div>
+            <!--  Partie Reseau
+              DESTINATION DISPLAY
+              FLEXIBLE POINT PROPERTIES
+              FLEXIBLE LINK PROPERTIES
+              SERVICE JOURNEY PATTERN
+              POINT IN JOURNEY PATTERN
+              SCHEDULED STOP POINT
+              TIMING POINT
+              TRANSFER RESTRICTION
+              PASSENGER STOP ASSIGNMENT
+              FLEXIBLE STOP ASSIGNMENT
+              TRAIN STOP ASSIGNMENT
+              SCHEMATIC MAP  
+            -->
+          </members>
+        </GeneralFrame>
 
-<table>
-<colgroup>
-<col style="width: 6%" />
-<col style="width: 12%" />
-<col style="width: 14%" />
-<col style="width: 8%" />
-<col style="width: 29%" />
-<col style="width: 29%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Classifi­cation</strong></th>
-<th><strong>Name</strong></th>
-<th><strong>Type</strong></th>
-<th></th>
-<th><strong>Description</strong></th>
-<th></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>::></td>
-<td>::></td>
-<td><em>DataManagedObject</em></td>
-<td>::></td>
-<td><p>TYPE OF VALUE hérite de <em><strong>DataManagedObject</strong></em>.</p>
-<p><span class="hl">L’attribut </span><em><strong><span class="hl">version</span></strong></em><span class="hl"> portera la version du profil</span>.</p>
-<p><span class="hl">L'Identifiant du TYPE OF VALUE est imposé à NETEX_ LIGNE</span>.</p></td>
-<td></td>
-</tr>
-<tr class="even">
-<td></td>
-<td><em><strong>Name</strong></em></td>
-<td><em>MultilingualString</em></td>
-<td>1:1</td>
-<td><p>Nom du TYPE OF VALUE.</p>
-<p><span class="hl">Imposé à « NETEX LIGNE»</span>.</p></td>
-<td></td>
-</tr>
-<tr class="odd">
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="even">
-<td></td>
-<td><em><strong>Description</strong></em></td>
-<td><em>MultilingualString</em></td>
-<td>1:1</td>
-<td><p>Description du TYPE OF VALUE.</p>
-<p><span class="hl">Imposé à « Profil d’échange français NETEX LIGNE»</span>.</p></td>
-<td></td>
-</tr>
-<tr class="odd">
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="even">
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="odd">
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-</tbody>
-</table>
-
-## TypeOfFrame : type spécifique *NETEX\_ RESEAU*
-
-Le présent profil utilise un *TypeOfFrame* spécifique, identifié
-***NETEX_RESEAU***.
-
-<div class="table-title">TypeOfFrame – Element</div>
-
-<table>
-<colgroup>
-<col style="width: 9%" />
-<col style="width: 17%" />
-<col style="width: 19%" />
-<col style="width: 12%" />
-<col style="width: 41%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Classifi­cation</strong></th>
-<th><strong>Nom</strong></th>
-<th><strong>Type</strong></th>
-<th></th>
-<th><strong>Description</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>::></td>
-<td>::></td>
-<td><em>TypeOfValueDataManagedObject</em></td>
-<td><em>::>::></em></td>
-<td><p>TYPE OF FRAME hérite de TYPE OF VALUE.</p>
-<p><span class="hl">L'Id est imposé à NETEX_</span><span class="hl"> </span><span class="hl">RESEAU</span></p></td>
-</tr>
-
-
-<tr class="even">
-<td>«cntd»</td>
-<td><em><strong>classes</strong></em></td>
-<td><em>ClassInContextRef</em></td>
-<td>0:*</td>
-<td><p>Liste des classes pouvant être contenu dans ce TYPE OF FRAME.</p>
-<p><span class="hl">La liste est fixe pour NETEX_ RESEAU:</span></p>
-<ul>
-<li><p><span class="hl">GENERAL FRAME de type NETEX_LIGNE</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">TARIFF ZONE</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">DESTINATION DISPLAY</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">FLEXIBLE POINT PROPERTIES</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">FLEXIBLE LINK PROPERTIES</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">SERVICE JOURNEY PATTERN</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">POINT IN JOURNEY PATTERN</span></p></li>
-</ul>
-</ul>
-<ul>
-<li><p><span class="hl">SERVICE LINK</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">SCHEDULED STOP POINT</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">TIMING POINT</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">CONNECTION</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">DEFAULT CONNECTION</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">SITE CONNECTION</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">ROUTING CONSTRAINT ZONE</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">TRANSFER RESTRICTION</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">PASSENGER STOP ASSIGNMENT</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">TRAIN STOP ASSIGNMENT</span></p></li>
-</ul>
-<ul>
-<li><p><span class="hl">SCHEMATIC MAP</span></p></li>
-</ul></td>
-</tr>
-
-
-</tbody>
-</table>
-
-<div class="table-title">TypeOfValue (pour le TypeOfFrame NETEX\_ RESEAU) – Element</div>
-
-<table>
-<colgroup>
-<col style="width: 6%" />
-<col style="width: 12%" />
-<col style="width: 14%" />
-<col style="width: 8%" />
-<col style="width: 29%" />
-<col style="width: 29%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Classifi­cation</strong></th>
-<th><strong>Name</strong></th>
-<th><strong>Type</strong></th>
-<th></th>
-<th><strong>Description</strong></th>
-<th></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>::></td>
-<td>::></td>
-<td><em>DataManagedObject</em></td>
-<td>::></td>
-<td><p>TYPE OF VALUE hérite de <em><strong>DataManagedObject</strong></em>.</p>
-<p><span class="hl">L’attribut </span><em><strong><span class="hl">version</span></strong></em><span class="hl"> portera la version du profil</span>.</p>
-<p><span class="hl">L'Identifiant du TYPE OF VALUE est imposé à NETEX_RESEAU</span>.</p></td>
-<td></td>
-</tr>
-<tr class="even">
-<td></td>
-<td><em><strong>Name</strong></em></td>
-<td><em>MultilingualString</em></td>
-<td>1:1</td>
-<td><p>Nom du TYPE OF VALUE.</p>
-<p><span class="hl">Imposé à « NETEX RESEAU»</span>.</p></td>
-<td></td>
-</tr>
-<tr class="odd">
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="even">
-<td></td>
-<td><em><strong>Description</strong></em></td>
-<td><em>MultilingualString</em></td>
-<td>1:1</td>
-<td><p>Description du TYPE OF VALUE.</p>
-<p><span class="hl">Imposé à « Profil d’échange français NETEX RESEAU»</span>.</p></td>
-<td></td>
-</tr>
-<tr class="odd">
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="even">
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="odd">
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-</tbody>
-</table>
+        <GeneralFrame id="FR:GeneralFrame:NETEX_HORAIRE-line_xyz:LOC" version="1.09:FR-NETEX-2.1-1.0">
+          <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_HORAIRE:" />
+          <members>
+            <!-- 
+              Peut contenir
+              SERVICE JOURNEY
+              SERVICE LINK
+              FLEXIBLE SERVICE PROPERTIES
+              TEMPLATE SERVICE JOURNEY
+              HEADWAY JOURNEY GROUP
+              RHYTHMICAL JOURNEY GROUP
+              COUPLED JOURNEY
+              JOURNEY PART COUPLE
+              JOURNEY PART
+              TRAIN
+              TRAIN COMPONENT
+              COMPOUND TRAIN
+              TRAIN NUMBER
+              TRAIN COMPONENT LABEL ASSIGNMENT
+            -->
+          </members>
+        </GeneralFrame>
+  </dataObjects>
+</PublicationDelivery>
+```
 
 Bibliographie
 

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -3392,16 +3392,15 @@ de du ministère des transport) et les POINTs D'ARRÊT PLANIFIÉs.
 communs. Seules les spécificités de la partie "description du réseau" sont présentées
 ici.*
 
-Deux FRAMEs distincts sont utilisées pour échanger la description des réseaux : 
+Deux FRAMEs distinctes sont utilisées pour échanger la description des réseaux : 
 - Une FRAME de type **NETEX_RESEAU**, utilisée dans le fichier "network.xml" 
 - Une FRAME de type **NETEX_LIGNE**, utilisée dans le fichier "line_xyz.xml" 
-  l'un pour n'échanger qu'une description de haut niveau des
 
-Pour rappel, la liste des fichiers d'un export NeTEx profil France est décrite dans Elements Communs.
+Pour rappel, la liste des fichiers d'un export NeTEx profil France est décrite dans Éléments Communs.
 
 ## TypeOfFrame : type spécifique *NETEX_RESEAU*
 
-Le losqu'une FRAME a pour TypeOfFrame la valeur `NETEX_RESEAU`, seules les objets de premier niveau suivants sont autorisés : 
+Lorsqu'une FRAME a pour TypeOfFrame la valeur `NETEX_RESEAU`, seules les objets de premier niveau suivants sont autorisés : 
 - Network
 - GroupOfLines
 - RoutingContraintZone
@@ -3409,11 +3408,11 @@ Le losqu'une FRAME a pour TypeOfFrame la valeur `NETEX_RESEAU`, seules les objet
 Voici un exemple de cadre du fichier `network.xml` :
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.09:FR-NETEX-2.1-1.0">
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="2.0:FR-NETEX-2.4">
   <PublicationTimestamp>2025-02-27T00:00:00.0Z</PublicationTimestamp>
   <ParticipantRef>Exemple</ParticipantRef>
   <dataObjects>
-    <GeneralFrame id="exemple:GeneralFrame:NETEX_RESEAU_1" version="1.09:FR-NETEX-2.1-1.0">
+    <GeneralFrame id="exemple:GeneralFrame:NETEX_RESEAU_1" version="2.0:FR-NETEX-2.4">
       <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_RESEAU:" />
       <members>
         <!--
@@ -3429,7 +3428,7 @@ Voici un exemple de cadre du fichier `network.xml` :
 
 ## TypeOfFrame : type spécifique *NETEX_LINE* et *NETEX_LIGNE_STRUCTURE*
 
-Le losqu'une FRAME a pour TypeOfFrame la valeur `NETEX_LINE`, il s'agit un objet `CompositeFrame`, lui-même composé de :
+Lorsqu'une FRAME a pour TypeOfFrame la valeur `NETEX_LINE`, il s'agit un objet `CompositeFrame`, lui-même composé de :
 - Une GeneralFrame de type `NETEX_LIGNE_STRUCTURE` (voir ci-dessous)
 - Une GeneralFrame de type `NETEX_HORAIRE`, décrit dans la partie Horaires du profil
 
@@ -3460,14 +3459,14 @@ La Frame de type `NETEX_LIGNE_STRUCTURE` ne contient que les objets de premier n
 Voici un exemple de cadre du fichier `line_xyz.xml` :
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.09:FR-NETEX-2.1-1.0">
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="2.0:FR-NETEX-2.4">
   <PublicationTimestamp>2023-01-01T00:00:00.0Z</PublicationTimestamp>
   <ParticipantRef>Exemple</ParticipantRef>
   <dataObjects>
     <CompositeFrame id="FR:CompositeFrame:NETEX_LIGNE-line_xyz:LOC" version="any">
       <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_LIGNE:" />
       <frames>
-        <GeneralFrame id="FR:GeneralFrame:NETEX_RESEAU-line_xyz:LOC" version="1.09:FR-NETEX-2.1-1.0">
+        <GeneralFrame id="FR:GeneralFrame:NETEX_RESEAU-line_xyz:LOC" version="2.0:FR-NETEX-2.4">
           <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_LIGNE_STRUCTURE:" />
           <members>
             <Line id="sample" version="any">
@@ -3502,7 +3501,7 @@ Voici un exemple de cadre du fichier `line_xyz.xml` :
           </members>
         </GeneralFrame>
 
-        <GeneralFrame id="FR:GeneralFrame:NETEX_HORAIRE-line_xyz:LOC" version="1.09:FR-NETEX-2.1-1.0">
+        <GeneralFrame id="FR:GeneralFrame:NETEX_HORAIRE-line_xyz:LOC" version="2.0:FR-NETEX-2.4">
           <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_HORAIRE:" />
           <members>
             <!-- 

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -3400,7 +3400,7 @@ Pour rappel, la liste des fichiers d'un export NeTEx profil France est décrite 
 
 ## TypeOfFrame : type spécifique *NETEX_RESEAU*
 
-Lorsqu'une FRAME a pour TypeOfFrame la valeur `NETEX_RESEAU`, seules les objets de premier niveau suivants sont autorisés : 
+Lorsqu'une FRAME a pour TypeOfFrame la valeur `NETEX_RESEAU`, seuls les objets de premier niveau suivants sont autorisés : 
 - Network
 - GroupOfLines
 - RoutingContraintZone


### PR DESCRIPTION
Cette PR :
- retravaille la description des TypeOfFrame pour la simplifier
- ajoute dans Elements Communs les type de Frame pour les fichiers resource.xml et poi.xml https://github.com/etalab/transport-profil-netex-fr/issues/115 et https://github.com/etalab/transport-profil-netex-fr/issues/116 )
- ajoute les frames correspondant aux fichiers network.xml (https://github.com/etalab/transport-profil-netex-fr/issues/160) et line-xyz.xml (https://github.com/etalab/transport-profil-netex-fr/issues/113) dans Network

Si le format de cette PR convient, les autres parties du profil seront à faire.