### PR TITLE
Mise à jour des numéros de version

### DIFF
--- a/NeTEx/_index.md
+++ b/NeTEx/_index.md
@@ -1,5 +1,5 @@
 ---
 title: NeTEx
-summary: Liste des normes NeTEx pour le profil France
-description: Cette page regroupe les documentations des normes NeTEx pour le profil France.
+summary: Liste des parties du profil France de la norme NeTEx
+description: Cette page regroupe toutes les parties du profil France de la norme NeTEx (CEN/TS 16614 series)
 ---

--- a/NeTEx/accessibilite/index.md
+++ b/NeTEx/accessibilite/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Profil NeTEx accessibilité France - v2.3"
+title: "Profil NeTEx accessibilité France - v2.4.0"
 date: 2024-11-21T00:00:00+00:05
 draft: false
 tags: ["NeTEx"]

--- a/NeTEx/accessibilite/index.md
+++ b/NeTEx/accessibilite/index.md
@@ -1,6 +1,6 @@
 ---
-title: "Profil NeTEx accessibilité France - v2.4.0"
-date: 2024-11-21T00:00:00+00:05
+title: "Profil NeTEx accessibilité France - v2.4"
+date: 2025-12-191T11:05:00+00:00
 draft: false
 tags: ["NeTEx"]
 autonumbering: true

--- a/NeTEx/arrets/index.md
+++ b/NeTEx/arrets/index.md
@@ -1,6 +1,6 @@
 ---
-title: "NeTEx - Profil France v2.4.0 - Description des arrêts"
-date: 2024-11-21T00:00:00+00:01
+title: "NeTEx - Profil France v2.4 - Description des arrêts"
+date: 2025-12-191T11:05:00+00:00
 draft: false
 tags: ["NeTEx"]
 autonumbering: true

--- a/NeTEx/arrets/index.md
+++ b/NeTEx/arrets/index.md
@@ -1,5 +1,5 @@
 ---
-title: "NeTEx - Profil France v2.3 - Description des arrêts"
+title: "NeTEx - Profil France v2.4.0 - Description des arrêts"
 date: 2024-11-21T00:00:00+00:01
 draft: false
 tags: ["NeTEx"]

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -1,5 +1,5 @@
 ---
-title: "NeTEx - Profil France v2.3 - Éléments communs"
+title: "NeTEx - Profil France v2.4.0 - Éléments communs"
 date: 2024-11-21T00:00:00+00:00
 draft: false
 tags: ["NeTEx"]

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -1,6 +1,6 @@
 ---
-title: "NeTEx - Profil France v2.4.0 - Éléments communs"
-date: 2024-11-21T00:00:00+00:00
+title: "NeTEx - Profil France v2.4 - Éléments communs"
+date: 2025-12-191T11:05:00+00:00
 draft: false
 tags: ["NeTEx"]
 autonumbering: true

--- a/NeTEx/horaires/index.md
+++ b/NeTEx/horaires/index.md
@@ -1,5 +1,5 @@
 ---
-title: "NeTEx - Profil France v2.3 - Horaires"
+title: "NeTEx - Profil France v2.4.0 - Horaires"
 date: 2024-11-21T00:00:00+00:02
 draft: false
 tags: ["NeTEx"]

--- a/NeTEx/horaires/index.md
+++ b/NeTEx/horaires/index.md
@@ -1,6 +1,6 @@
 ---
-title: "NeTEx - Profil France v2.4.0 - Horaires"
-date: 2024-11-21T00:00:00+00:02
+title: "NeTEx - Profil France v2.4 - Horaires"
+date: 2025-12-191T11:05:00+00:00
 draft: false
 tags: ["NeTEx"]
 autonumbering: true

--- a/NeTEx/parkings/index.md
+++ b/NeTEx/parkings/index.md
@@ -1,5 +1,5 @@
 ---
-title: "NeTEx - Profil France v2.3 - Parkings"
+title: "NeTEx - Profil France v2.4.0 - Parkings"
 date: 2024-11-21T00:00:00+00:02
 draft: false
 tags: ["NeTEx"]

--- a/NeTEx/parkings/index.md
+++ b/NeTEx/parkings/index.md
@@ -1,6 +1,6 @@
 ---
-title: "NeTEx - Profil France v2.4.0 - Parkings"
-date: 2024-11-21T00:00:00+00:02
+title: "NeTEx - Profil France v2.4 - Parkings"
+date: 2025-12-191T11:05:00+00:00
 draft: false
 tags: ["NeTEx"]
 autonumbering: true

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -1,5 +1,5 @@
 ---
-title: "NeTEx - Profil France v2.3 - Description des réseaux"
+title: "NeTEx - Profil France v2.4.0 - Description des réseaux"
 date: 2024-11-21T00:00:00+00:04
 draft: false
 tags: ["NeTEx"]

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -1,6 +1,6 @@
 ---
-title: "NeTEx - Profil France v2.4.0 - Description des réseaux"
-date: 2024-11-21T00:00:00+00:04
+title: "NeTEx - Profil France v2.4 - Description des réseaux"
+date: 2025-12-191T11:05:00+00:00
 draft: false
 tags: ["NeTEx"]
 autonumbering: true

--- a/NeTEx/tarifs/index.md
+++ b/NeTEx/tarifs/index.md
@@ -1,5 +1,5 @@
 ---
-title: "NeTEx - Profil France v2.3 - Tarifs"
+title: "NeTEx - Profil France v2.4.0 - Tarifs"
 date: 2024-11-21T00:00:00+01:00
 draft: false
 tags: ["NeTEx"]

--- a/NeTEx/tarifs/index.md
+++ b/NeTEx/tarifs/index.md
@@ -1,6 +1,6 @@
 ---
-title: "NeTEx - Profil France v2.4.0 - Tarifs"
-date: 2024-11-21T00:00:00+01:00
+title: "NeTEx - Profil France v2.4 - Tarifs"
+date: 2025-12-191T11:05:00+00:00
 draft: false
 tags: ["NeTEx"]
 autonumbering: true


### PR DESCRIPTION
En travaillant sur la mise à jour du site pour que ça soit compatible avec une récupération "par tag" (`v2.4.0`), j'ai vu dans mes tests que le numéro de version dans les titres n'était pas à jour, je commence à mettre à jour ici.

Il faudra également retoucher les dates, mais je n'ai pas les bonnes infos pour ça pour le moment.