### PR TITLE
Clarification pour l'obligation de l'attribut Location dans Point

### DIFF
--- a/NeTEx/arrets/index.md
+++ b/NeTEx/arrets/index.md
@@ -1375,6 +1375,8 @@ plates-formes composites à deux côtés ou plus ou à des sections nommées.
 </tbody>
 </table>
 
+<span class="h1"><strong>NOTE IMPORTANTE</strong> : Le profil France rend obligatoire l'attribut <em>Location</em> du STOP PLACE</span>
+
 ### Attributs de Place
 
 <div class="table-title">Place – Element (abstrait)</div>
@@ -1928,8 +1930,7 @@ Français de NETEx: éléments communs**:
 
 -   SiteElement: 7.2.8
 
-<div class="table-title">Quay (traduit par ZONE D'EMBARQUEMENT en français) –</div>
-Element
+<div class="table-title">Quay (traduit par ZONE D'EMBARQUEMENT en français) – Element</div>
 
 <table>
 <colgroup>
@@ -2012,6 +2013,8 @@ Element
 
 </tbody>
 </table>
+
+<span class="h1"><strong>NOTE IMPORTANTE</strong> : Le profil France rend obligatoire l'attribut <em>Location</em> du QUAY</span>
 
 <div class="table-title">Espace de Lieu d’Arrêt – Element (abstrait)</div>
 

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -1311,7 +1311,7 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td><em>Location</em></td>
 <td>0:1
 <p><strong><span class="hl">1 :1</span></strong></p></td>
-<td>Localisation du POINT <span class="hl">(Obligatoire dans le profil France, uniquement pour les objets de type QUAY et STOP PLACE - L'attribut n'est pas attendu dans les SCHEDULED STOP POINT)</span></td>
+<td>Localisation du POINT <span class="hl">(Obligatoire dans le profil France, notamment pour les objets de type QUAY et STOP PLACE. Attention, l'attribut n'est pas attendu dans les SCHEDULED STOP POINT)</span></td>
 </tr>
 <tr class="odd">
 <td>«»</td>

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -1309,9 +1309,9 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td></td>
 <td><em><strong>Location</strong></em></td>
 <td><em>Location</em></td>
-<td><p>0:1</p>
+<td>0:1
 <p><strong><span class="hl">1 :1</span></strong></p></td>
-<td>Localisation du POINT <span class="hl">(Obligatoire dans le profil, sauf si les structures héritées ont des références explicites à des points/zones géographiques)</span></td>
+<td>Localisation du POINT <span class="hl">(Obligatoire dans le profil France, uniquement pour les objets de type QUAY et STOP PLACE - L'attribut n'est pas attendu dans les SCHEDULED STOP POINT)</span></td>
 </tr>
 <tr class="odd">
 <td>«»</td>

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -1311,7 +1311,7 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td><em>Location</em></td>
 <td><p>0:1</p>
 <p><strong><span class="hl">1 :1</span></strong></p></td>
-<td>Localisation du POINT <span class="hl">(obligatoire dans le profil)</span></td>
+<td>Localisation du POINT <span class="hl">(Obligatoire dans le profil, sauf si les structures héritées ont des références explicites à des points/zones géographiques)</span></td>
 </tr>
 <tr class="odd">
 <td>«»</td>

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -2220,6 +2220,8 @@ manœuvre de retournement).
 </tbody>
 </table>
 
+<span class="h1"><strong>NOTE IMPORTANTE</strong> : Le profil France ne retient pas l'attribut <em>Location</em> du SCHEDULED STOP POINT, l'information est portée par les objets QUAY ou STOP PLACE.</span>
+
 ### Parcours horaire
 
 Le profil étant dédié à l'information voyageur, on se limitera, pour la


### PR DESCRIPTION
Clarification que l'attribut Location d'un Point NeTEx est obligatoire sous condition, notamment pour éviter les redondances dans ScheduledStopPoint

Voir #34 pour plus de détails