### PR TITLE
Uniformisation highlights

### DIFF
--- a/NeTEx/accessibilite/index.md
+++ b/NeTEx/accessibilite/index.md
@@ -238,12 +238,12 @@ EN 12896, Public transport - Reference data model (Transmodel)
 
 NOTE Pour les besoins du présent document, les termes et définitions
 suivants s'appliquent. Ils sont directement issus de la traduction
-française de Transmodel et NeTEx <span class="hl">(on notera que
+française de Transmodel et NeTEx <mark>(on notera que
 certaines traductions sont un peu « étonnantes », toutefois il a été
 jugé préférable de rester cohérent avec la traduction officielle). Il
 conviendra souvent de se référer au corps du document car certaines
 traductions officielles peuvent amener à une totale incompréhension des
-concepts.</span>
+concepts.</mark>
 
 Pour une information complète, il conviendra toutefois de se référer au
 document normatif.
@@ -1046,7 +1046,7 @@ proposent ces colonnes:
     les textes surlignés en jaune indiquent une spécificité du profil
     par rapport à NeTEx).
 
-Les textes surlignés en <span class="hl">Jaune</span> sont ceux
+Les textes surlignés en <mark>Jaune</mark> sont ceux
 présentant une particularité (spécialisation) par rapport à NeTEx : une
 codification particulière, une restriction d'usage, etc.
 
@@ -1108,15 +1108,12 @@ gare, accès possibles pour les UFR uniquement sur certains quais)
 signalétique auditive en cas de perturbations mais pas d'annonces pour
 les prochains passages)
 
-<span class="hl">Dans le cadre du profil France il est convenu, lorsque
-"</span>***<span class="hl">Partiel</span>***<span class="hl">" est
-utilisé, de systématiquement remplir le champ "</span>***<span
-class="hl">ValidityCondition->Description</span>***<span class="hl">"
+<mark>Dans le cadre du profil France il est convenu, lorsque "***Partiel***" est
+utilisé, de systématiquement remplir le champ "***ValidityCondition->Description***"
 pour préciser comment l'information doit être interprétée. Il est à noter
-que seul le champ </span>***<span class="hl">ValidityCondition</span>***
-<span class="hl"> permet de contenir une description textuelle, sous forme d'un
-texte libre susceptible d'être présenté au public en complément des
-indicateurs ci-dessus.</span>
+que seul le champ ***ValidityCondition*** permet de contenir une description
+textuelle, sous forme d'un texte libre susceptible d'être présenté au public en
+complément des indicateurs ci-dessus.</mark>
 
 ![image](media/image8.svg)
 *Accessibilité dans les autres parties du profil France*
@@ -1173,7 +1170,7 @@ précision sur les équipements et cheminements rencontrés.
 <td><em>MultilingualString</em></td>
 <td>0:1</td>
 <td><p>Commentaire complémentaire sur l'accessibilité.</p>
-<p><span class="hl">Ce champ a pour vocation à compléter, en termes d'information voyageur, l'information générale de la structure. Il a donc pour vocation à être affiché avec les informations d'accessibilité.</span></p></td>
+<p><mark>Ce champ a pour vocation à compléter, en termes d'information voyageur, l'information générale de la structure. Il a donc pour vocation à être affiché avec les informations d'accessibilité.</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -1210,9 +1207,7 @@ recommandé (pour des raisons de cohérence) que sa valeur soit:
 
 ## Adéquation aux besoins
 
-<span class="hl">L'adéquation aux besoins n'est pas retenue dans le
-cadre du profill accessibilité.</span>
-
+<mark>L'adéquation aux besoins n'est pas retenue dans le cadre du profil accessibilité.</mark>
 
 ## Les services disponibles
 
@@ -1255,8 +1250,8 @@ etc.) et POSSIBILITÉ DE RESTER À BORD (ONBOARD STAY).
 | «PK» | id | FacilitySetIdType | 1:1 | Identifiant du FACILITY SET. |
 | | ***ProvidedByRef*** | OrganisationRef | 0:1 | ORGANISATION en charge de proposer le FACILITY SET. |
 | | Description | MultilingualString | 0:1 | Description du FACILITY SET. |
-| «FK» | TypeOfFacilityRef | *TypeOfFacilityRef* | 0:1 | Classification du FACILITY SET. <span class="hl">Non retenu dans le profil France jusqu'à son harmonisation.</span> |
-| «cntd» | otherFacilities | _*TypeOfEquipment*_ / *TypeTypeOfEquipmentRef* | 0:\* | Types de FACILITY arbitraires définis par l'utilisateur dans FACILITY SET, leur définition renvoie à des TYPES OF EQUIPMENT. <span class="hl">Non retenu dans le profil France jusqu'à son harmonisation.</span> |
+| «FK» | TypeOfFacilityRef | *TypeOfFacilityRef* | 0:1 | Classification du FACILITY SET. <mark>Non retenu dans le profil France jusqu'à son harmonisation.</mark> |
+| «cntd» | otherFacilities | _*TypeOfEquipment*_ / *TypeTypeOfEquipmentRef* | 0:\* | Types de FACILITY arbitraires définis par l'utilisateur dans FACILITY SET, leur définition renvoie à des TYPES OF EQUIPMENT. <mark>Non retenu dans le profil France jusqu'à son harmonisation.</mark> |
 | «cntd» | (CommonFacilityGroup) | xxxFacilitList | 0:\* | FACILITIEs sont définies comme des listes de valeurs énumérées de types fixes qui sont communes à tous les FACILITY SETs. Il existe d'autres FACILITIEs spécifiques aux SERVICE FACILITY SET et SITE FACILITY SET. |
 
 <div class="table-title">ServiceFacilitySet – Élément</div>
@@ -1287,8 +1282,8 @@ etc.) et POSSIBILITÉ DE RESTER À BORD (ONBOARD STAY).
 | | ***PassengerCommsFacilityList*** | *PassengerCommsFacilityListOfEnumerations* | 0:1  | Listes des services de communication. |
 
 
-Les SERVICES DISPONIBLES communs à toutes ces spécialisations et <span
-class="hl">retenus dans le cadre du profil sont les suivants </span>:
+Les SERVICES DISPONIBLES communs à toutes ces spécialisations et
+<mark>retenus dans le cadre du profil sont les suivants</mark> :
 
 ***<u>-Information d'accessibilité</u>***
 
@@ -1357,8 +1352,8 @@ accompagnés)*
 
 * *suitableForWheelchairs (adapté aux fauteuils roulants)*
 
-* *suitableForHeavilyDisabled (adapté aux handicaps lourds ; <span class="hl">
-note : prendre contact avec le gestionnaire pour plus de précisions</span>)*
+* *suitableForHeavilyDisabled (adapté aux handicaps lourds ; <mark>
+note : prendre contact avec le gestionnaire pour plus de précisions</mark>)*
 
 * *suitableForPushchairs (adapté aux poussettes)*
 
@@ -1429,8 +1424,8 @@ ligne)*
 * *mobileTicketing (billettique mobile – sur smartphone)*
 
 Les SERVICES DISPONIBLES de type Service (sans redondance des catégories
-précédentes) <span class="hl">retenus dans le cadre du profil sont les
-suivants </span>:
+précédentes) <mark>retenus dans le cadre du profil sont les
+suivants</mark> :
 
 ***<u>-Services Réservés</u>***
 
@@ -1449,8 +1444,8 @@ les fauteuils roulants notamment)*
 * *cyclesAllowed (vélos autorisés en bagage)*
 
 Les SERVICES DISPONIBLES spécifiques aux lieux (sans redondance des
-catégories précédentes) <span class="hl">retenus dans le cadre du profil
-sont les suivants </span>:
+catégories précédentes) <mark>retenus dans le cadre du profil
+sont les suivants</mark> :
 
 ***<u>-Urgence</u>***
 
@@ -1484,8 +1479,8 @@ station)*
 * *unmanned (sans personnel)*
 
 Les SERVICES DISPONIBLES disponible au niveau de la place, lors du
-voyage (sans redondance des catégories précédentes) <span
-class="hl">retenus dans le cadre du profil sont les suivants :</span>
+voyage (sans redondance des catégories précédentes) <mark>retenus dans le cadre
+du profil sont les suivants</mark> :
 
 ***<u>Installation</u>***
 
@@ -1501,11 +1496,11 @@ C'est une notion qu'il faut considérer de façon générale et un service
 (SERVICE LOCAL tel qu’OBJETS TROUVÉS, BILLETTERIE) est également
 considéré comme un ÉQUIPEMENT.
 
-<span class="hl">Dans le cadre du profil pour l'accessibilité, la
+<mark>Dans le cadre du profil pour l'accessibilité, la
 description des équipements est recommandée à chaque fois que cela est
 possible (et que l'information est disponible). La description des
 ÉQUIPEMENTs est donc préférée à la description des services
-disponibles.</span>
+disponibles.</mark>
 
 ### Équipements localisés
 
@@ -1576,8 +1571,8 @@ que le trouvera aussi bien en station que dans une rame de TGV).
 <td><em>PublicCode</em></td>
 <td>0:1</td>
 <td><p>Code public de l’équipement, et qui figure généralement sur l’équipement, typiquement sous la forme d’une étiquette.</p>
-<p><span class="hl">Pourra contenir des codes comme, par exemple, les codes MIR de la RATP</span></p>
-<p><span class="hl">Notez que ce code doit être accessible/préhensible sur l'équipement (notament en vue d'utilisation pour du crowd-sourcing et de la signalisation d'anomalie, etc.)</span></p></td>
+<p><mark>Pourra contenir des codes comme, par exemple, les codes MIR de la RATP.</mark></p>
+<p><mark>Notez que ce code doit être accessible/préhensible sur l'équipement (notament en vue d'utilisation pour du crowd-sourcing et de la signalisation d'anomalie, etc.).</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1585,7 +1580,7 @@ que le trouvera aussi bien en station que dans une rame de TGV).
 <td>xsd:anyURI</td>
 <td>0:1</td>
 <td><p>Image de l’EQUIPEMENT.</p>
-<p><span class="hl">Pourra aussi référencer des documents audio, des pages web, etc</span></p></td>
+<p><mark>Pourra aussi référencer des documents audio, des pages web, etc</mark>.</p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -1600,7 +1595,7 @@ que le trouvera aussi bien en station que dans une rame de TGV).
 <td>MultilingualString</td>
 <td>0:1</td>
 <td>Description de l’EQUIPEMENT.<br />
-<span class="hl">Doit pouvoir être présenté au public</span></td>
+<mark>Doit pouvoir être présenté au public.</mark></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1608,7 +1603,7 @@ que le trouvera aussi bien en station que dans une rame de TGV).
 <td>MultilingualString</td>
 <td>0:1</td>
 <td>Note concernat l’EQUIPEMENT.<br />
-<span class="hl">Doit pouvoir être présenté au public</span></td>
+<mark>Doit pouvoir être présenté au public.</mark></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1616,7 +1611,7 @@ que le trouvera aussi bien en station que dans une rame de TGV).
 <td>boolean</td>
 <td>0:1</td>
 <td><p>Indique si l’équipement est hors service pour une durée prolongée. Une véritable information de disponibilité en temps réel pourra être fournie avec le service SIRI Facility Monitoring.</p>
-<p><span class="hl">Quand </span><em><strong><span class="hl">OutOfService</span></strong></em><span class="hl"> est utilisé, l'utilisation du ValidityCondition devient obligatoire pour, en particulier, indiquer la période prévue d'indisponibilité (et donc la date prévue de retour en fonctionnement)</span></p></td>
+<p><mark>Quand <em><strong>OutOfService</strong></em> est utilisé, l'utilisation du ValidityCondition devient obligatoire pour, en particulier, indiquer la période prévue d'indisponibilité (et donc la date prévue de retour en fonctionnement).</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -1908,9 +1903,9 @@ recommandé de ne pas trop les subdiviser (et donc de ne pas les faire
 trop petits) pour éviter de surcharger l'utilisateur en information et
 aussi pour limiter le volume d'information à gérer par les systèmes.
 
-<span class="hl">À noter qu’en présence de bandes de guidage, il est obligatoire de créer un 
+<mark>À noter qu’en présence de bandes de guidage, il est obligatoire de créer un
 ou plusieurs objets SitePathLink pour les modéliser avec l'attribut *TactileGuidingStrip* dûment renseigné. 
-Sa définition détaillée est en Table 11 plus bas. </span>
+Sa définition détaillée est en Table 11 plus bas.</mark>
 
 <div class="table-title">SitePathLink – Élément</div>
 
@@ -1949,18 +1944,18 @@ Sa définition détaillée est en Table 11 plus bas. </span>
 <td>Distance</td>
 <td>DistanceType</td>
 <td><p>0:1</p>
-<p><span class="hl">1:1</span></p></td>
+<p><mark>1:1</mark></p></td>
 <td><p>Longueur du tronçon de cheminement.</p>
-<p><span class="hl">L'attribut Distance, hérité de LINK, est rendu obligatoire pour les tronçons de cheminement par le profil pour l'accessibilité. Il s'agit de la distance parcourue le long du tronçon de cheminement et non de la distance à vol d'oiseau entre les points de départ et d'arrivée.</span></p></td>
+<p><mark>L'attribut Distance, hérité de LINK, est rendu obligatoire pour les tronçons de cheminement par le profil pour l'accessibilité. Il s'agit de la distance parcourue le long du tronçon de cheminement et non de la distance à vol d'oiseau entre les points de départ et d'arrivée.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
 <td>LineString</td>
 <td>gmlLineString</td>
 <td><p>0:1</p>
-<p><span class="hl">1:1</span></p></td>
+<p><mark>1:1</mark></p></td>
 <td><p>Géométrie du tronçon de cheminement.</p>
-<p><span class="hl">Dans le contexte du profil pour l'accessibilité, la géométrie des PATH LINKs sera systématiquement décrite avec l'attribut <em><strong>LineString</strong></em> (GML) hérité de LINK. Il est important de bien noter que cette géométrie peut être différente, notament au niveau des extrémités, des centroïdes des objets référencés par <em><strong>From</strong></em> et <em><strong>To</strong></em> (qui sont généralement des centroïdes de zone, relativement imprécis). De plus les extrémités du LineString devront coïncider avec ceux des autres PATH LINK connectés dans le cadre d'un NAVIGATION PATH.</span></p></td>
+<p><mark>Dans le contexte du profil pour l'accessibilité, la géométrie des PATH LINKs sera systématiquement décrite avec l'attribut <em><strong>LineString</strong></em> (GML) hérité de LINK. Il est important de bien noter que cette géométrie peut être différente, notament au niveau des extrémités, des centroïdes des objets référencés par <em><strong>From</strong></em> et <em><strong>To</strong></em> (qui sont généralement des centroïdes de zone, relativement imprécis). De plus les extrémités du LineString devront coïncider avec ceux des autres PATH LINK connectés dans le cadre d'un NAVIGATION PATH.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -1975,7 +1970,7 @@ Sa définition détaillée est en Table 11 plus bas. </span>
 <td>PathLinkEnd</td>
 <td>1:1</td>
 <td><p>Point ou lieu de fin du PATH LINK. Voir tableau suivant</p>
-<p><em><strong><span class="hl">From</span></strong></em><span class="hl"> et </span><em><strong><span class="hl">To</span></strong></em><span class="hl"> peuvent référencer le même espace, mais avec des </span><em><strong><span class="hl">LineString </span></strong><span class="hl">(voir ci-dessus)</span></em><span class="hl"> différentes. On utilisera notament cette particularité pour traverser des équipements long (comme un tapis roulant) situés dans un EQUIPMENT PLACE (ZONE).</span></p></td>
+<p><mark><em><strong>From</strong></em> et <em><strong>To</strong></em> peuvent référencer le même espace, mais avec des <em><strong>LineString</strong> (voir ci-dessus)</em> différentes. On utilisera notament cette particularité pour traverser des équipements long (comme un tapis roulant) situés dans un EQUIPMENT PLACE (ZONE).</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1997,7 +1992,7 @@ Sa définition détaillée est en Table 11 plus bas. </span>
 <td>xsd:boolean</td>
 <td>0:1</td>
 <td><p>Indique si le cheminement est ouvert au public.</p>
-<p><span class="hl">Public (true) par défaut (si l'attribut n'est pas fourni)</span></p></td>
+<p><mark>Public (true) par défaut (si l'attribut n'est pas fourni).</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -2005,7 +2000,7 @@ Sa définition détaillée est en Table 11 plus bas. </span>
 <td>CoveredEnum</td>
 <td>0:1</td>
 <td>Type de couverture.
-<p><span class="hl">La valeur <em>mixed</em> est déconseillée dans le cadre du profil pour l'accessibilité : il convient dans ce cas de segmenter en plusieurs SitePathLink avec chacun un type de couverture propre.</span></p></td>
+<p><mark>La valeur <em>mixed</em> est déconseillée dans le cadre du profil pour l'accessibilité : il convient dans ce cas de segmenter en plusieurs SitePathLink avec chacun un type de couverture propre.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2061,7 +2056,7 @@ Sa définition détaillée est en Table 11 plus bas. </span>
 <td>xsd:integer</td>
 <td>0:1</td>
 <td>Nombre de marches rencontrées sur le cheminement.
-<p><span class="hl">Il s'agit du nombre de marches total de l'escalier si le tronçon de cheminement correspond à un escalier, ou du nombre de ressauts ou marches isolées sinon.</span></p></td>
+<p><mark>Il s'agit du nombre de marches total de l'escalier si le tronçon de cheminement correspond à un escalier, ou du nombre de ressauts ou marches isolées sinon.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2069,8 +2064,8 @@ Sa définition détaillée est en Table 11 plus bas. </span>
 <td>LengthType</td>
 <td>0:1</td>
 <td><p>Largeur minimale du cheminement</p>
-<p><span class="hl">La largeur renseignée doit tenir compte des éventuels obstacles présents le long du tronçon de cheminement.</span></p>
-<p><span class="hl">Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les ascenseurs et trottoirs.</span></p>    
+<p><mark>La largeur renseignée doit tenir compte des éventuels obstacles présents le long du tronçon de cheminement.</mark></p>
+<p><mark>Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les ascenseurs et trottoirs.</mark></p>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2089,7 +2084,7 @@ Sa définition détaillée est en Table 11 plus bas. </span>
 <li><p><em>up (montée)</em></p></li>
 <li><p><em>down (descente)</em></p></li>
 <li><p><em>level (pas de changement de niveau)</em></p></li>
-</ul><p><span class="hl">Les valeurs <em>upAndDown</em> (montée puis descente) et <em>downAndUp</em> (descente puis montée) sont déconseillées dans le cadre du profil pour l'accessibilité : il convient dans ces cas de segmenter en plusieurs SitePathLink avec chacun un type de transition propre.</span></p></td>
+</ul><p><mark>Les valeurs <em>upAndDown</em> (montée puis descente) et <em>downAndUp</em> (descente puis montée) sont déconseillées dans le cadre du profil pour l'accessibilité : il convient dans ces cas de segmenter en plusieurs SitePathLink avec chacun un type de transition propre.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2097,7 +2092,7 @@ Sa définition détaillée est en Table 11 plus bas. </span>
 <td>xsd:integer</td>
 <td>0:1</td>
 <td><p>Pente en degrés (dans le sens direct, from/to, du cheminement)</p>
-<p><span class="hl">Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les trottoirs.</span></p>   
+<p><mark>Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les trottoirs.</mark></p>
 </td>
 </tr>
 <tr class="odd">
@@ -2106,7 +2101,7 @@ Sa définition détaillée est en Table 11 plus bas. </span>
 <td>xsd:integer</td>
 <td>0:1</td>
 <td><p>Dévers (inclinaison latérale) de +20 a -20 degrés (dans le sens direct, from/to, du cheminement)</p>
-<p><span class="hl">Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les trottoirs.</span></p>   
+<p><mark>Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les trottoirs.</mark></p>
 </td>
 </tr>
 <tr class="even">
@@ -2241,7 +2236,7 @@ Sa définition détaillée est en Table 11 plus bas. </span>
 <li><p><em>noTactileStrip (pas de bandes d’interception)</em></p></li>
 <li><p><em>unknown (inconnu)</em></p></li>
 </ul>
-<p><span class="hl">Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les escaliers et passages piétons.</span></p>   
+<p><mark>Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les escaliers et passages piétons.</mark></p>
 </td>
 </tr>
 <tr class="odd">
@@ -2250,8 +2245,8 @@ Sa définition détaillée est en Table 11 plus bas. </span>
 <td>xsd:boolean</td>
 <td>0:1</td>
 <td><p>Indique s’il y a des bandes de guidage podotactiles.</p>
-<p><span class="hl">En cas de présence de bandes de guidage podotactiles, il 
-est obligatoire de renseigner les tronçons de cheminement correspondants.</span></p></td>
+<p><mark>En cas de présence de bandes de guidage podotactiles, il
+est obligatoire de renseigner les tronçons de cheminement correspondants.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>
@@ -2705,7 +2700,7 @@ passagers)* *–* Élément
 |                     | Wheelchair­TurningCircle     | LengthType             | 0:1              | Diamètre de giration pour les fauteuils roulants                                           |
 |                     | SharpsDisposal              | xsd:boolean            | 0:1              | Disponibilité d’une poubelle pour objets tranchants                                        |
 |                     | Staffing                    | StaffingEnum           | 0:1              | Présence de personnel                                                                      |
-|                     | KeyScheme                   | xsd:normalizedString   | 0:1              | <span class="hl">Texte libre décrivant les conditions d'accessibilité : peut notamment compléter les informations comme</span><br /><span class="hl">- Espaces usage, barres de transfert, position du cercle de retournement, lave main (présence, hauteur), position du papier toilette, etc.</span>         |
+|                     | KeyScheme                   | xsd:normalizedString   | 0:1              | <mark>Texte libre décrivant les conditions d'accessibilité : peut notamment compléter les informations comme<br />- Espaces usage, barres de transfert, position du cercle de retournement, lave main (présence, hauteur), position du papier toilette, etc.</mark>         |
 |                     | CallButtonAvailable         | xsd:boolean            | 0:1              | Présence d’un bouton d’appel                                                               |
 |                     | SupportBarHeigth            | xsd:decimal            | 0:1              | Hauteur de la barre de support (quand il y en a une)                                       |
 |                     | LockedAccess                | xsd:boolean            | 0:1              | Indique si les toilettes peuvent être verrouillées et donc une clé (ou un outil équivalent) est nécessaire pour y accéder. |
@@ -2883,7 +2878,7 @@ passagers)* *–* Élément
 
 ## Access Equipment
 
-<span class="hl">Dans le cas des entrées de gare, l'attribut *Width* est rendu obligatoire par l'arrêté du 28 mai 2024. Voir le détail dans la table ci-après.</span>
+<mark>Dans le cas des entrées de gare, l'attribut *Width* est rendu obligatoire par l'arrêté du 28 mai 2024. Voir le détail dans la table ci-après.</mark>
 
 <div class="table-title">AccessEquipment (équipement d’accès) – Élément</div>
 
@@ -2895,9 +2890,9 @@ passagers)* *–* Élément
 |                     | ***DirectionOfUse***  | DirectionOfUseEnum         | 0:1              | Direction dans laquelle on peut emprunter l’accès (les deux par defaut) |
 |                     | ***SafeForGuideDog*** | *xsd:boolean*              | 0:1              | Signale si l’accès est sans risqué pour un chien guide.                 |
 
-<span class="hl">En cas de présence de bandes d’interception podotactiles, il est
+<mark>En cas de présence de bandes d’interception podotactiles, il est
 obligatoire renseigner l’attribut *TactileWarningStrip* dans tout *CrossingEquipment*. 
-Voir la table ci-après pour la description de cet élément.</span>
+Voir la table ci-après pour la description de cet élément.</mark>
 
 <div class="table-title">CrossingEquipment (croisements et traversées) – Élément</div>
 
@@ -2972,7 +2967,7 @@ Voir la table ci-après pour la description de cet élément.</span>
 <td>xsd:boolean</td>
 <td>0:1</td>
 <td><p>Signale la présence d’une aide acoustique à la traversée</p>
-<p><span class="hl">Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les passages piétons.</span></p> 
+<p><mark>Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les passages piétons.</mark></p>
 </td>
 </tr>
 <tr class="odd">
@@ -3054,16 +3049,16 @@ Voir la table ci-après pour la description de cet élément.</span>
 <li><p><em>noTactileStrip</em> (pas de bande d’interception)</p></li>
 <li><p><em>unknown</em> (inconnu)</p></li>
 </ul>
-<p><span class="hl">Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les passages piétons.</span></p> 
+<p><mark>Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les passages piétons.</mark></p>
 </td>
 </tr>
 </tbody>
 </table>
 
-<span class="hl">Il faudra porter une attention toute particulière aux éléments de
+<mark>Il faudra porter une attention toute particulière aux éléments de
 description des *EntranceEquipment* (entrées), notamment sur le détail des types de porte 
 et plus particulièrement les attributs *RevolvingDoor*, *AutomaticDoor*,
-*NecessaryForceToOpen* détaillés dans la table ci-après.</span>
+*NecessaryForceToOpen* détaillés dans la table ci-après.</mark>
 
 <div class="table-title">EntranceEquipment (entrées) – Élément</div>
 
@@ -3080,7 +3075,7 @@ et plus particulièrement les attributs *RevolvingDoor*, *AutomaticDoor*,
 |                     | EntranceRequires­Staffing    | xsd:boolean            | 0:1              | Signale que le passage requiert la présence d’agents du personnel                          |
 |                     | EntranceRequiresTicket      | xsd:boolean            | 0:1              | Signale que le passage requiert un ticket                                                  |
 |                     | AcousticSensor              | xsd:boolean            | 0:1              | Signale la présence de capteurs acoustiques                                                |
-|                     | AutomaticDoor               | xsd:boolean            | 0:1              | Signale que la porte est à ouverture/fermeture automatique<br><span class="hl">Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les entrées de gare.</span>                 |
+|                     | AutomaticDoor               | xsd:boolean            | 0:1              | Signale que la porte est à ouverture/fermeture automatique<br><mark>Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les entrées de gare.</mark>                 |
 |                     | DropKerbOutside             | xsd:boolean            | 0:1              | Signale la présence de bateaux (abaissement du trottoir) au franchissement du passage      |
 |                     | GlassDoor                   | xsd:boolean            | 0:1              | Signale la présence d’une porte vitrée                                                     |
 |                     | WheelchairPassable          | xsd:boolean            | 0:1              | Signale la possibilité de franchissement en fauteuil roulant.                              |
@@ -3090,13 +3085,13 @@ et plus particulièrement les attributs *RevolvingDoor*, *AutomaticDoor*,
 |                     | Airlock                     | xsd:boolean            | 0:1              | Signale la présence d’un sas                                                               |
 |                     | DoorstepMark                | xsd:boolean            | 0:1              | Signale la présente d’une marque de seuil (de franchissement) podotactile.                 |
 |                     | AudioPassthroughIndicator   | xsd:boolean            | 0:1              | Signale la présente d’un signal sonore de franchissement.                                  |
-|                     | NecessaryForceToOpen        | NecessaryForceEnum     | 0:1              | Force nécessaire pour l’ouverture de la porte <li><p><em>noForce</em> (aucune force nécessaire)</p></li> <li><p><em>lightForce</em> (force légère)</p></li><li><p><em>mediumForce</em> (force moyenne)</p></li><li><p><em>heavyForce</em> (force importante)</p></li><li><p><em>unknown</em> (inconnu)</p></li><br><span class="hl">Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les entrées de gare.</span>                 |
+|                     | NecessaryForceToOpen        | NecessaryForceEnum     | 0:1              | Force nécessaire pour l’ouverture de la porte <li><p><em>noForce</em> (aucune force nécessaire)</p></li> <li><p><em>lightForce</em> (force légère)</p></li><li><p><em>mediumForce</em> (force moyenne)</p></li><li><p><em>heavyForce</em> (force importante)</p></li><li><p><em>unknown</em> (inconnu)</p></li><br><mark>Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les entrées de gare.</mark>                 |
 |                     | DoorHandleOutside           | DoorTypeEnumeration    | 0:1              | Caractéristiques de la poignée de porte à l'extérieur <li><p><em>lever</em> (poignée classique)</p></li> <li><p><em>button</em> (bouton)</p></li><li><p><em>grabRail</em> (poignée de tirage)</p></li><li><p><em>windowLever</em> (levier de fenêtre)</p></li><li><p><em>vertical</em> (bâton de maréchal, barre verticale)</p></li><li><p><em>knob</em> (poignée ronde)</p></li><li><p><em>crashBar</em> (barre antipanique)</p></li><li><p><em>other</em> (autre type de poignée)</p></li><li><p><em>none</em> (pas de poignée)</p></li>                |
 |                     | DoorHandleInside            | DoorTypeEnumeration    | 0:1              | Caractéristiques de la poignée de porte à l'intérieur <li><p><em>lever</em> (poignée classique)</p></li> <li><p><em>button</em> (bouton)</p></li><li><p><em>grabRail</em> (poignée de tirage)</p></li><li><p><em>windowLever</em> (levier de fenêtre)</p></li><li><p><em>vertical</em> (bâton de maréchal, barre verticale)</p></li><li><p><em>knob</em> (poignée ronde)</p></li><li><p><em>crashBar</em> (barre antipanique)</p></li><li><p><em>other</em> (autre type de poignée)</p></li><li><p><em>none</em> (pas de poignée)</p></li>                |
 |                     | RampDoorbell                | xsd:boolean            | 0:1              | Lorsqu'il y a une rampe amovible pour accéder à l'entrée, indique la présence d’une sonnette au droit de la rampe                 |
 |                     | Recognizable                | xsd:boolean            | 0:1              | Indique si l’entrée est facilement repérable dans son environnement en tenant compte de l'architecture, de la signalisation et du contraste visuel. On met *false* lorsque l'entrée est difficile à repérer.                              |
-|                     | TurningSpacePosition        | EntranceTurningSpacePositionEnumeration   | 0:1              | Indique la présence, à proximité immédiate de la porte, d'un espace pour la manœuvrer correctement (au minimum un diamètre d'1,5m). <li><p><em>outside</em> (à l'extérieur)</p></li> <li><p><em>inside</em> (à l'intérieur)</p></li><li><p><em>insideAndOutside</em> (à l'intérieur et à l'extérieur)</p></li><li><p><em>none</em> (pas d'espace de manœuvre)</p></li> <br><br><span class="hl">Voir l'annexe informative pour plus d'informations sur le remplissage de l'attribut.</span>                                  |
-|                     | WheelchairTurningCircle     | LengthType            | 0:1              | Diamètre de giration pour les fauteuils roulants <br><span class="hl">On considèrera le diamètre du plus petit espace de manœuvre (intérieur ou extérieur).</span>                              |
+|                     | TurningSpacePosition        | EntranceTurningSpacePositionEnumeration   | 0:1              | Indique la présence, à proximité immédiate de la porte, d'un espace pour la manœuvrer correctement (au minimum un diamètre d'1,5m). <li><p><em>outside</em> (à l'extérieur)</p></li> <li><p><em>inside</em> (à l'intérieur)</p></li><li><p><em>insideAndOutside</em> (à l'intérieur et à l'extérieur)</p></li><li><p><em>none</em> (pas d'espace de manœuvre)</p></li> <br><br><mark>Voir l'annexe informative pour plus d'informations sur le remplissage de l'attribut.</mark>                                  |
+|                     | WheelchairTurningCircle     | LengthType            | 0:1              | Diamètre de giration pour les fauteuils roulants <br><mark>On considèrera le diamètre du plus petit espace de manœuvre (intérieur ou extérieur).</mark>                              |
 
 <div class="table-title">QueueingEquipment (gestion de queue) – Élément</div>
 
@@ -3124,7 +3119,7 @@ et plus particulièrement les attributs *RevolvingDoor*, *AutomaticDoor*,
 |                     | *TactileGuidance­Strips*     | xsd:boolean                  | 0:1              | Indique si la rampe dispose d’une bande de guidage podotactile                          |
 |                     | *VisualGuidance­Bands*       | xsd:boolean                  | 0:1              | Indique si la rampe dispose de bandes de guidage visuelles                              |
 |                     | *Temporary*                 | xsd:boolean                  | 0:1              | Signale que la rampe est temporaire                                                     |
-|                     | *RestStopDistance*          | xsd:boolean                  | 0:1              | Distance maximale entre deux paliers de repos <br><span class="hl">Il est recommandé d'implanter un palier de repos en bas et en haut de chaque rampe, ainsi que tous les 10 mètres en cas de longue rampe.</span>  |
+|                     | *RestStopDistance*          | xsd:boolean                  | 0:1              | Distance maximale entre deux paliers de repos <br><mark>Il est recommandé d'implanter un palier de repos en bas et en haut de chaque rampe, ainsi que tous les 10 mètres en cas de longue rampe.</mark>  |
 | «enum»              | *SafetyEdge*                | SafetyEdgeEnum               | 0:1              | Indique la présence d'une bordure chasse-roue. Il s'agit d'une bordure latérale visant à bloquer la roue du fauteuil roulant pour éviter les chutes. <br><ul><li><em>oneSide </em>(d’un côté uniquement)</li><li><em>bothSides </em>(des deux côtés)</li><li><em>none </em>(pas de chasse-roue)</li></ul>   |
 | «enum»              | *TurningSpace*              | RampTurningSpacePositionEnum | 0:1              | Indique la présence d'une aire de rotation (ou espace de manœuvre) UFR en bas et/ou en haut de la rampe : <br><ul><li><em>bottom </em>(en bas uniquement)</li><li><em>top </em>(en haut uniquement)</li><li><em>topAndBottom </em>(en haut et en bas)</li><li><em>none</em> (pas d'aire de rotation)</li><li><em>level</em> (plat)</li></ul>      |
 
@@ -3315,7 +3310,7 @@ et plus particulièrement les attributs *RevolvingDoor*, *AutomaticDoor*,
 <td>xsd:boolean</td>
 <td>0:1</td>
 <td><p>Indique la présence d'une bande visuellement contrastée permettant de bien distinguer le bord des marches.</p>
-<p><span class="hl">Les bandes doivent être présentes sur chaque marche, sur l'intégralité de la largeur des marches et d'une profondeur de 2 cm.</span></p>
+<p><mark>Les bandes doivent être présentes sur chaque marche, sur l'intégralité de la largeur des marches et d'une profondeur de 2 cm.</mark></p>
 </td>
 </tr>
 <tr class="odd">
@@ -3377,7 +3372,7 @@ et plus particulièrement les attributs *RevolvingDoor*, *AutomaticDoor*,
 <td>StairEnd</td>
 <td>0:1</td>
 <td><p>Caractérisation de l’extrémité haute de l’escalier</p>
-<p><span class="hl">Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les bandes d'éveil de vigilance en haut des escaliers.</span></p>
+<p><mark>Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les bandes d'éveil de vigilance en haut des escaliers.</mark></p>
 </td>
 </tr>
 <tr class="even">
@@ -3424,9 +3419,9 @@ et plus particulièrement les attributs *RevolvingDoor*, *AutomaticDoor*,
 
 | **Classifi­cation** | **Nom**             | **Type**         | **Cardin­alité** | **Description**                        |
 | --------------- | ------------- | ---------------------- | ------------ | --------------------------------------------- |
-|                     | Continuing­Handrail | xsd:boolean | 0:1              | Indique si la main courante de l'escalier se prolonge au-delà des marches. <br> <span class="hl">La prolongation doit être au moins égale à la largeur d'une marche.</span>                                                                                                            |
-|                     | TexturedSurface     | xsd:boolean | 0:1              | Signale une surface au sol texturée. <br> <span class="hl">On indiquera ainsi la présence d'une bande d'éveil à la vigilance (BEV).</span>                                                                                                                                             |
-|                     | VisualContrast      | xsd:boolean | 0:1              | Indique un signalement (du début ou de la fin de l’escalier suivant le cas) par contraste de couleur.  <br> <span class="hl">On indiquera ainsi par exemple la présence de contremarches d'une couleur différente du reste de l'escalier pour la première et la dernière marche.</span> |
+|                     | Continuing­Handrail | xsd:boolean | 0:1              | Indique si la main courante de l'escalier se prolonge au-delà des marches. <br> <mark>La prolongation doit être au moins égale à la largeur d'une marche.</mark>                                                                                                            |
+|                     | TexturedSurface     | xsd:boolean | 0:1              | Signale une surface au sol texturée. <br> <mark>On indiquera ainsi la présence d'une bande d'éveil à la vigilance (BEV).</mark>                                                                                                                                             |
+|                     | VisualContrast      | xsd:boolean | 0:1              | Indique un signalement (du début ou de la fin de l’escalier suivant le cas) par contraste de couleur.  <br> <mark>On indiquera ainsi par exemple la présence de contremarches d'une couleur différente du reste de l'escalier pour la première et la dernière marche.</mark> |
 
 <div class="table-title">StairFlight (volées de marche d’escalier) – Élément</div>
 
@@ -3466,7 +3461,7 @@ et plus particulièrement les attributs *RevolvingDoor*, *AutomaticDoor*,
 | ------------------ | --------------------------- | -------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | *::>*              | *::>*                       | PlaceAccessEquipment | *::>*           | LIFT hérite de ACCESS EQUIPMENT                                                                                                                                                                                                                                                                                                                                                                       |
 | «PK»               | id                          | LiftIdType           | 1:1             | identifiant du LiftEquipement                                                                                                                                                                                                                                                                                                                                                                         |
-|                    | Depth                       | LengthType           | 0:1             | Profondeur de l’ascenseur      <br><span class="hl">Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les ascenseurs.</span>                                                                                                                                                                                                                                                         |
+|                    | Depth                       | LengthType           | 0:1             | Profondeur de l’ascenseur      <br><mark>Cet élément est rendu obligatoire par l'arrêté du 28 mai 2024 pour les ascenseurs.</mark>                                                                                                                                                                                                                                                         |
 |                    | MaximumLoad                 | WeightType           | 0:1             | Charge maximale                                                                                                                                                                                                                                                                                                                                                                                       |
 |                    | WheelchairPassable          | xsd:boolean          | 0:1             | Signale si l’utilisation en fauteuil roulant est possible                                                                                                                                                                                                                                                                                                                                             |
 |                    | WheelchairTurningCircle     | LengthType           | 0:1             | Diamètre de giration pour les fauteuils roulants dans l’ascenseur                                                                                                                                                                                                                                                                                                                                     |
@@ -3575,7 +3570,7 @@ et plus particulièrement les attributs *RevolvingDoor*, *AutomaticDoor*,
 <td>xsd:anyUrl</td>
 <td>0:1</td>
 <td><p>URL associée d’information associée au panneau ou au signe.</p>
-<p><span class="hl">Doit être conforme à l'accessibilité RGAA</span></p></td>
+<p><mark>Doit être conforme à l'accessibilité RGAA</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -3777,7 +3772,7 @@ et plus particulièrement les attributs *RevolvingDoor*, *AutomaticDoor*,
 <td><p>Type of assistance fournie :</p>
 <ul>
 <li><p><em>personalAssistance</em> (personnel d’assistance)</p></li>
-<li><p><em>boardingAssistance <span class="hl">(le champ Description sera utilisé pour préciser l'assistant à l'embarquement/débarquement, notament dans le cas des correspondances multimodales)</span></em></p></li>
+<li><p><em>boardingAssistance <mark>(le champ Description sera utilisé pour préciser l'assistant à l'embarquement/débarquement, notament dans le cas des correspondances multimodales)</mark></em></p></li>
 <li><p><em>wheechairAssistance</em> (assistance pour les fauteuils roulants)</p></li>
 <li><p><em>unaccompaniedMinorAssistance</em> (assistance pour les mineurs non accompagnés)</p></li>
 <li><p><em>wheelchairUse</em> (utilisation de fauteil roulant)</p></li>

--- a/NeTEx/arrets/index.md
+++ b/NeTEx/arrets/index.md
@@ -874,7 +874,7 @@ proposent ces colonnes:
     les textes surlignés en jaune indiquent une spécificité du profil
     par rapport à NeTEx).
 
-Les textes surlignés en <span class="hl">jaune</span> sont ceux
+Les textes surlignés en <mark>jaune</mark> sont ceux
 présentant une particularité (spécialisation) par rapport à NeTEx: une
 codification particulière, une restriction d'usage, etc.
 
@@ -1274,7 +1274,7 @@ plates-formes composites à deux côtés ou plus ou à des sections nommées.
 <td><em>Site</em></td>
 <td><em>::></em></td>
 <td><p>STOP PLACE hérite de SITE.</p>
-<p><span class="hl">NOTE L'identification du STOP PLACE a pour vocation à être codifiée. Sa codification est décrite le document </span><strong><span class="hl">éléments communs</span>.</strong></p></td>
+<p><mark>NOTE : L'identification du STOP PLACE a pour vocation à être codifiée. Sa codification est décrite dans le document <strong>éléments communs</strong>.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«AK»</td>
@@ -1303,7 +1303,7 @@ plates-formes composites à deux côtés ou plus ou à des sections nommées.
 <p><em>WaterSubmode</em></p></td>
 <td>0:1</td>
 <td><p>Sous mode associé au mode (caractérise le type d’exploitation). Les sous modes sont une énumération dont les valeurs sont présentées en 7.2.10.</p>
-<p><span class="hl">Il faut noter le cas particulier du Tram-Train qui, bien qu'étant classé en sous-mode du TRAM, peut aussi être utilisé en sous-mode du Ferré.</span></p></td>
+<p><mark>Il faut noter le cas particulier du Tram-Train qui, bien qu'étant classé en sous-mode du TRAM, peut aussi être utilisé en sous-mode du Ferré.</mark></p></td>
 </tr>
 <tr class="even">
 <td>submode</td>
@@ -1322,7 +1322,7 @@ plates-formes composites à deux côtés ou plus ou à des sections nommées.
 <td><em>FareZoneRef</em></td>
 <td>0:*</td>
 <td><p>Identifiant de la zone tarifaire (ou section selon les cas) précisé dans le fichier `fare.xml`.</p>
-<p>Si la zone tarifaire n'est pas précisée (le champ étant facultatif) mais que la <em><strong>StopPlace</strong></em> est inclue dans une autre <span class="hl">(LIEU D'ARRÊT MONOMODAL dans une LIEU D'ARRÊT MULTIMODAL par exemple)</span> qui lui a une <em><strong>FareZone</strong></em>, alors la ou les zones tarifaires du <em><strong>StopPlace</strong></em> parent s'appliquent.</p>
+<p>Si la zone tarifaire n'est pas précisée (le champ étant facultatif) mais que la <em><strong>StopPlace</strong></em> est inclue dans une autre <mark>(LIEU D'ARRÊT MONOMODAL dans une LIEU D'ARRÊT MULTIMODAL par exemple)</mark> qui lui a une <em><strong>FareZone</strong></em>, alors la ou les zones tarifaires du <em><strong>StopPlace</strong></em> parent s'appliquent.</p>
 <p>Le profil France fait une restriction de la norme NeTEx en demandant explicitement une FareZoneRef, alors que NeTEx indique TariffZone (dont FareZone est une spécialisation).</p>
 </td>
 </tr>
@@ -1348,7 +1348,7 @@ plates-formes composites à deux côtés ou plus ou à des sections nommées.
 <td><p>Qualification de la possibilité de correspondance au sein du lieu d’arrêt</p>
 <ul>
 <li><p><em><strong>noInterchange</strong></em></p></li>
-<li><p><em><strong>interchangeAllowed</strong> <span class="hl">(valeur par défaut si le champ n’est pas renseigné)</span></em></p></li>
+<li><p><em><strong>interchangeAllowed</strong> <mark>(valeur par défaut si le champ n’est pas renseigné)</mark></em></p></li>
 <li><p><em>preferredInterchange</em> (indique que le Lieu d’Arrêt est spécialement conçu pour faciliter les échanges, avec des chemins de guidage de chemin, un chemin de promenade facile, sécurisé et court, etc.).</p></li>
 </ul></td>
 </tr>
@@ -1370,7 +1370,7 @@ plates-formes composites à deux côtés ou plus ou à des sections nommées.
 <td><em><strong>quays</strong></em></td>
 <td><em>Quay</em></td>
 <td>0:*</td>
-<td>Liste des identifiants <span class="hl">(le profil fait le choix de définir les ZONEs D’EMBARQUEMENT indépendaemment et de les référencer)</span> des ZONEs D'EMBARQUEMENT contenues dans le LIEU <span class="hl">(exclusivement pour les LIEUx D'ARRÊT de type LIEUX D'ARRÊT MONOMODAL).</span></td>
+<td>Liste des identifiants <mark>(le profil fait le choix de définir les ZONEs D’EMBARQUEMENT indépendaemment et de les référencer)</mark> des ZONEs D'EMBARQUEMENT contenues dans le LIEU <mark>(exclusivement pour les LIEUx D'ARRÊT de type LIEUX D'ARRÊT MONOMODAL)</mark>.</td>
 </tr>
 </tbody>
 </table>
@@ -1402,52 +1402,44 @@ plates-formes composites à deux côtés ou plus ou à des sections nommées.
 <td>::></td>
 <td><em>Zone</em></td>
 <td>::></td>
-<td>PLACE hérite de ZONE <em><span class="hl">(voir le document éléments communs)</span></em><span class="hl">.</span></td>
+<td>PLACE hérite de ZONE <mark><em>(voir le document éléments communs)</em></mark>.</td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
 <td><em><strong>placeTypes</strong></em></td>
 <td><em>TypeOfPlaceRef</em></td>
 <td><p>0:*</p>
-<p><strong><span class="hl">0:1</span></strong></p>
-<p><em><strong><span class="hl">spécial</span></strong></em></p></td>
-<td><p><span class="hl">Cet attribut n'est utilisé que pour les LIEUx D'ARRÊT et les zones administratives (TOPOGRAPHIC PLACE), et il est alors obligatoire, et sa cardinalité est alors 1:1.</span></p>
-<p><span class="hl">Pour le LIEU D'ARRET Codification permettant de distinguer les:</span></p>
+<p><strong><mark>0:1</mark></strong></p>
+<p><em><strong><mark>spécial</mark></strong></em></p></td>
+<td><p><mark>Cet attribut n'est utilisé que pour les LIEUx D'ARRÊT et les zones administratives (TOPOGRAPHIC PLACE), et il est alors obligatoire, et sa cardinalité est alors 1:1.</mark></p>
+<p><mark>Pour le LIEU D'ARRET Codification permettant de distinguer les :</mark></p>
 <ul>
 <li>
-<p><span class="hl">LIEU D'ARRÊT MONOMODAL </span><br />
-<span class="hl">valeur: monomodalStopPlace</span></p>
+<p><mark>LIEU D'ARRÊT MONOMODAL <br/> valeur : monomodalStopPlace</mark></p>
 </li>
 <li>
-<p><span class="hl">PÔLE MONOMODAL</span><br />
-<span class="hl">valeur: monomodalHub</span></p>
+<p><mark>PÔLE MONOMODAL <br/> valeur : monomodalHub</mark></p>
 </li>
 <li>
-<p><span class="hl">LIEU D'ARRÊT MULTIMODAL</span><br />
-<span class="hl">valeur: multimodalStopPlace</span></p>
+<p><mark>LIEU D'ARRÊT MULTIMODAL <br/> valeur : multimodalStopPlace</mark></p>
 </li>
 </ul>
-<p><span class="hl">Type de zones administratives françaises (TOPOGRAPHIC PLACE), qui doit être cohérent avec les Topographic-PlaceType (voir ):</span></p>
+<p><mark>Type de zones administratives françaises (TOPOGRAPHIC PLACE), qui doit être cohérent avec les Topographic-PlaceType (voir ) :</mark></p>
 <ul>
 <li>
-<p><span class="hl">RÉGION </span><br />
-<span class="hl">valeur: region</span></p>
+<p><mark>RÉGION <br/> valeur : region</mark></p>
 </li>
 <li>
-<p><span class="hl">DÉPARTEMENT </span><br />
-<span class="hl">valeur: department</span></p>
+<p><mark>DÉPARTEMENT <br/> valeur : department</mark></p>
 </li>
 <li>
-<p><span class="hl">GROUPEMENT DE COMMUNES </span><br />
-<span class="hl">valeur: urbanCommunity</span></p>
+<p><mark>GROUPEMENT DE COMMUNES <br/> valeur : urbanCommunity</mark></p>
 </li>
 <li>
-<p><span class="hl">VILLE </span><br />
-<span class="hl">valeur: town</span></p>
+<p><mark>VILLE <br/> valeur : town</mark></p>
 </li>
 <li>
-<p><span class="hl">ARRONDISSEMENT </span><br />
-<span class="hl">valeur: </span><em><strong><span class="hl">district</span></strong></em></p>
+<p><mark>ARRONDISSEMENT <br/> valeur : <em><strong>district</strong></em></mark></p>
 </li>
 </ul></td>
 </tr>
@@ -1503,7 +1495,7 @@ la façon suivante:
 <td><em><strong>AccessibilityAssessment</strong></em></td>
 <td><em>AccessibilityAssessment</em></td>
 <td>0:1</td>
-<td><p>Information globale précisant le niveau d'accessibilité du <span class="hl">LIEU D'ARRÊT, de la ZONE D'EMBARQUEMENT ou de l'ACCÈS</span>.</p>
+<td><p>Information globale précisant le niveau d'accessibilité du <mark>LIEU D'ARRÊT, de la ZONE D'EMBARQUEMENT ou de l'ACCÈS</mark>.</p>
 <p>Voir le détail dans l'annexe 9 du profil Accessibilité.</p></td>
 </tr>
 <tr class="even">
@@ -1511,7 +1503,7 @@ la façon suivante:
 <td><em><strong>AccessModes</strong></em></td>
 <td><em>AccessModeEnum</em></td>
 <td>0:*</td>
-<td><p>Liste des modes utilisables (il peut donc y en avoir plusieurs) pour accéder à ce <span class="hl">LIEU D'ARRÊT (renseigné uniquement pour les LIEUx D'ARRÊT</span>):</p>
+<td><p>Liste des modes utilisables (il peut donc y en avoir plusieurs) pour accéder à ce <mark>LIEU D'ARRÊT (renseigné uniquement pour les LIEUx D'ARRÊT)</mark> :</p>
 <ul>
 <li>
 <p><em><strong>foot</strong></em>: À pied</p>
@@ -1540,7 +1532,7 @@ la façon suivante:
 <td><em><strong>alternativeNames</strong></em></td>
 <td><em>AlternativeName</em></td>
 <td>0:*</td>
-<td><p>Nom(s) alternatif(s) (potentiellement multiple) <span class="hl">du </span><span class="hl">LIEU D'ARRÊT, de la ZONE D'EMBARQUEMENT ou de l'ACCÈS</span>.</p>
+<td><p>Nom(s) alternatif(s) (potentiellement multiple) <mark>du LIEU D'ARRÊT, de la ZONE D'EMBARQUEMENT ou de l'ACCÈS</mark>.</p>
 <p>Voir le détail dans le profil Éléments Communs.</p></td>
 </tr>
 <tr class="odd">
@@ -1548,13 +1540,13 @@ la façon suivante:
 <td><em><strong>CrossRoad</strong></em></td>
 <td><em>MultilingualString</em></td>
 <td>0:1</td>
-<td>Identification du croisement (nom des rues de l'intersection) où se situe <span class="hl">le LIEU D'ARRÊT, la ZONE D'EMBARQUEMENT ou l'ACCÈS</span>..</td>
+<td>Identification du croisement (nom des rues de l'intersection) où se situe <mark>le LIEU D'ARRÊT, la ZONE D'EMBARQUEMENT ou l'ACCÈS</mark>..</td>
 </tr>
 <tr class="even">
 <td><em><strong>Landmark</strong></em></td>
 <td><em>MultilingualString</em></td>
 <td>0:1</td>
-<td>Nom d'un repère proche <span class="hl">du </span><span class="hl">LIEU D'ARRÊT, de la ZONE D'EMBARQUEMENT ou de l'ACCÈS</span> (par exemple "en face du café XXX", "juste après la bouche d'incendie", etc.).</td>
+<td>Nom d'un repère proche <mark>du LIEU D'ARRÊT, de la ZONE D'EMBARQUEMENT ou de l'ACCÈS</mark> (par exemple "en face du café XXX", "juste après la bouche d'incendie", etc.).</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1686,15 +1678,15 @@ la façon suivante:
 <td><em><strong>TopographicPlaceRef</strong></em></td>
 <td><em>TopographicPlaceRef</em></td>
 <td>0:1</td>
-<td>Référence à la zone administrative à laquelle appartient le <span class="hl">LIEU D'ARRÊT, la ZONE D'EMBARQUEMENT ou l'ACCÈS</span> (il s'agira ici uniquement d'une zone administrative de type Ville ou Arrondissement: c'est la structure administrative elle-même qui décrira les inclusions dans les zones administratives "supérieures").</td>
+<td>Référence à la zone administrative à laquelle appartient le <mark>LIEU D'ARRÊT, la ZONE D'EMBARQUEMENT ou l'ACCÈS</mark> (il s'agira ici uniquement d'une zone administrative de type Ville ou Arrondissement : c'est la structure administrative elle-même qui décrira les inclusions dans les zones administratives "supérieures").</td>
 </tr>
 <tr class="odd">
 <td></td>
 <td><em><strong>additionalTopographicPlaces</strong></em></td>
 <td><em>topographicPlaceRefs</em></td>
 <td>0 :*</td>
-<td><p>Un <span class="hl">LIEU D'ARRÊT</span> peut avoir des composants dans plusieurs communes d’où la cardinalité : ce champ permet de référencer toutes ces zones administratives (la précédente étant la principale).</p>
-<p><span class="hl">Cet attribut n'est utilisé que pour les LIEUx D'ARRÊT</span></p></td>
+<td><p>Un <mark>LIEU D'ARRÊT</mark> peut avoir des composants dans plusieurs communes d’où la cardinalité : ce champ permet de référencer toutes ces zones administratives (la précédente étant la principale).</p>
+<p><mark>Cet attribut n'est utilisé que pour les LIEUx D'ARRÊT.</mark></p></td>
 </tr>
 
 <tr class="odd">
@@ -1702,7 +1694,7 @@ la façon suivante:
 <td><em><strong>Locale</strong></em></td>
 <td><em>Locale</em></td>
 <td>0:1</td>
-<td><p>Information locales liées au <span class="hl">LIEU D'ARRÊT, ZONE D'EMBARQUEMENT ou ACCÈS</span> comme le fuseau horaire, la langue, etc.</p>
+<td><p>Information locales liées au <mark>LIEU D'ARRÊT, ZONE D'EMBARQUEMENT ou ACCÈS</mark> comme le fuseau horaire, la langue, etc.</p>
 <p>Voir Profil Éléments Communs.</p></td>
 </tr>
 <tr class="even">
@@ -1717,12 +1709,12 @@ la façon suivante:
 <td><em><strong>ParentSiteRef</strong></em></td>
 <td><em>SiteRef</em></td>
 <td>0:1</td>
-<td><p><span class="hl">Référence au LIEU D'ARRÊT "contenant" le présent LIEU. Cette liaison est contrainte en fonction de la spécialisation du LIEU D'ARRÊT:</span></p>
+<td><p><mark>Référence au LIEU D'ARRÊT "contenant" le présent LIEU. Cette liaison est contrainte en fonction de la spécialisation du LIEU D'ARRÊT :</mark></p>
 <ul>
-<li><p><span class="hl">LIEU D'ARRET MONOMODAL : parent= LIEU D'ARRÊT MULTIMODAL ou POLE MONOMODAL</span></p></li>
-<li><p><span class="hl">POLE MONOMODAL : parent= LIEU D'ARRÊT MULTIMODAL</span></p></li>
-<li><p><span class="hl">LIEU D'ARRÊT MULTIMODAL = pas de parent</span></p>
-<p><span class="hl">Cet attribut n'est utilisé que pour les LIEUx D'ARRÊT</span></p></li>
+<li><p><mark>LIEU D'ARRET MONOMODAL : parent &equiv; LIEU D'ARRÊT MULTIMODAL ou POLE MONOMODAL</mark></p></li>
+<li><p><mark>POLE MONOMODAL : parent &equiv; LIEU D'ARRÊT MULTIMODAL</mark></p></li>
+<li><p><mark>LIEU D'ARRÊT MULTIMODAL &equiv; pas de parent</mark></p>
+<p><mark>Cet attribut n'est utilisé que pour les LIEUx D'ARRÊT</mark></p></li>
 </ul></td>
 </tr>
 
@@ -1738,7 +1730,7 @@ la façon suivante:
 <p><levelRef ref="Banlieue"/></p>
 <p><levelRef ref="GrandeLigne"/></p>
 <p></levels></p>
-<p><span class="hl">Cet attribut n'est utilisé que pour les LIEUx D'ARRÊT</span></p></td>
+<p><mark>Cet attribut n'est utilisé que pour les LIEUx D'ARRÊT.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
@@ -1746,7 +1738,7 @@ la façon suivante:
 <td><em>Entrance</em></td>
 <td>0:*</td>
 <td><p>Lien vers les entrées du LIEU (référence des ACCÈS)</p>
-<p><span class="hl">Cet attribut n'est utilisé que pour les LIEUx D'ARRÊT</span></p></td>
+<p><mark>Cet attribut n'est utilisé que pour les LIEUx D'ARRÊT.</mark></p></td>
 </tr>
 
 </tbody>
@@ -1899,18 +1891,14 @@ correspondants.
 | «enum»              | ***TransportMode***    | *VehicleModeEnum*         | 0:1              | Principal MODE de transport pour ce groupe Voir STOP PLACE pour les valeurs. |
 | «enum»              | ***TransportSubmode*** | *SubmodeEnum*             | 0:1              | Principal SOUS MODE de transport pour ce groupe                              |
 
-<span class="hl">Note : de façon à assurer la compatibilité avec les
+<mark>Note : de façon à assurer la compatibilité avec les
 travaux d’Île-de-France Mobilité, on conserve temporairement la
 possibilité de décrire le groupe de lieux, avec un GroupOfEntities dont
-le champ </span>**<span
-class="hl">PurposeofGroupingRef</span>**<span class="hl"> sera
-instancié avec "</span>**<span
-class="hl">groupOfStopPlace</span>**<span class="hl">" et dont
-</span>***<span class="hl">members</span>***<span class="hl">
-contient la liste des identifiants des membres des GROUPEs DE LIEUX
-D'ARRÊT (ce sont donc exclusivement des identifiants de LIEU D'ARRÊT).
-Cette possibilité n’est valable que pour les données produite en
-Île-de-France.</span>
+le champ **PurposeofGroupingRef** sera instancié avec **"groupOfStopPlace"** et
+dont ***members*** contient la liste des identifiants des membres des
+GROUPEs DE LIEUX D'ARRÊT (ce sont donc exclusivement des identifiants de
+LIEU D'ARRÊT). Cette possibilité n’est valable que pour les données produites en
+Île-de-France.</mark>
 
 ## Zone d'embarquement
 
@@ -1954,7 +1942,7 @@ Français de NETEx: éléments communs**:
 <td><em>StopPlaceSpace</em></td>
 <td><em>::></em></td>
 <td><p>QUAY hérite de STOP PLACE SPACE et STOP PLACE COMPONENT.</p>
-<p><span class="hl">NOTE Pour les ZONE D'EMBARQUEMENT l'identification a pour vocation à être codifiée: voir Éléments Communs.</span></p></td>
+<p><mark>NOTE : Pour les ZONE D'EMBARQUEMENT l'identification a pour vocation à être codifiée : voir Éléments Communs.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>QUAY IDENTIFIER GROUP</td>
@@ -1962,7 +1950,7 @@ Français de NETEx: éléments communs**:
 <td><em>xsd:normalizedString</em></td>
 <td>0:1</td>
 <td><p>Code court connu du public pour identifier le LIEU D'ARRÊT (utilisé par exemple pour les services SMS, etc.)</p>
-<p><span class="hl">Dans le cas des trains, en particulier, le nom des voies (« Voie A », « Voix 2B », « Voix 1 », etc.) est à mettre dans ce </span><em><strong><span class="hl">PublicCode</span></strong></em><span class="hl"> et non dans le </span><em><strong><span class="hl">Name</span></strong></em><span class="hl"> (qui contiendra le nom de l’arrêt, « Versailles Chantier » par exemple, de façon à ce qu’un service d’information voyageur puis indique « descendez à Versailles Chantier » et précise « Voie 2B » et ne se contente pas de dire « descendez voix 2B »…)</span></p></td>
+<p><mark>Dans le cas des trains, en particulier, le nom des voies (« Voie A », « Voix 2B », « Voix 1 », etc.) est à mettre dans ce <em><strong>PublicCode</strong></em> et non dans le <em><strong>Name</strong></em> (qui contiendra le nom de l’arrêt, « Versailles Chantier » par exemple, de façon à ce qu’un service d’information voyageur puis indique « descendez à Versailles Chantier » et précise « Voie 2B » et ne se contente pas de dire « descendez voix 2B »…).</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -2001,7 +1989,7 @@ Français de NETEx: éléments communs**:
 <li><p><em><strong>ferryLanding</strong></em>: Accostage de ferry</p></li>
 <li><p><em><strong>telecabinePlatform</strong></em>: Quai de téléphérique</p></li>
 </ul>
-<p><span class="hl">NOTE NeTEx propose aussi </span><em><strong><span class="hl">taxiStand</span></strong></em><span class="hl">, </span><em><strong><span class="hl">setDownPlace</span></strong></em><span class="hl"> et </span><em><strong><span class="hl">other </span></strong></em><span class="hl">mais ces valeurs ne sont pas retenues dans le cadre du présent profil.</span></p></td>
+<p><mark>NOTE : NeTEx propose aussi <em><strong>taxiStand</strong></em>, <em><strong>setDownPlace</strong></em> et <em><strong>other</strong></em> mais ces valeurs ne sont pas retenues dans le cadre du présent profil.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -2055,11 +2043,11 @@ Français de NETEx: éléments communs**:
 <td><em><strong>SiteRef</strong></em></td>
 <td><em>SiteRef</em></td>
 <td><p>0:1</p>
-<p><span class="hl">1:1</span></p></td>
-<td><p><span class="hl">Pour une ZONE D'EMBARQUEMENT, il s'agit de l'identifiant du LIEU D'ARRÊT MONOMODAL dont dépend la ZONE D'EMBARQUEMENT.</span></p>
-<p><span class="hl">Pour un ACCÈS il s'agit de l'identifiant du LIEU D'ARRÊT MONOMODAL, POLE MONOMODAL ou LIEU D'ARRÊT MULTIMODAL auquel mène l'ACCÈS.</span></p>
-<p><span class="hl">Cet attribut est obligatoire dans le cadre du profil.</span></p>
-<p><span class="hl">Note : de plus, notament pour faciliter les conversions vers le profil Européen, on systématisera l’includion XML des </span><em><strong><span class="hl">SiteComponents</span></strong></em><span class="hl"> dans les </span><em><strong><span class="hl">Sites.</span></strong></em></p></td>
+<p><mark>1:1</mark></p></td>
+<td><p><mark>Pour une ZONE D'EMBARQUEMENT, il s'agit de l'identifiant du LIEU D'ARRÊT MONOMODAL dont dépend la ZONE D'EMBARQUEMENT.</mark></p>
+<p><mark>Pour un ACCÈS il s'agit de l'identifiant du LIEU D'ARRÊT MONOMODAL, POLE MONOMODAL ou LIEU D'ARRÊT MULTIMODAL auquel mène l'ACCÈS.</mark></p>
+<p><mark>Cet attribut est obligatoire dans le cadre du profil.</mark></p>
+<p><mark>Note : de plus, notament pour faciliter les conversions vers le profil Européen, on systématisera l’inclusion XML des <em><strong>SiteComponents</strong></em> dans les <em><strong>Sites</strong></em>.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -2068,11 +2056,6 @@ Français de NETEx: éléments communs**:
 <td>0:1</td>
 <td>Niveau (étages) du lieu d'arrêt auquel se situe la ZONE D'EMBARQUEMENT ou l'ACCÈS. Il est identifié par son nom : cela peut être "<strong>1</strong>", "<strong>A</strong>", "<strong>Banlieue</strong>", etc.</td>
 </tr>
-
-
-
-
-
 </tbody>
 </table>
 
@@ -2102,8 +2085,8 @@ Français de NETEx: éléments communs**:
 <td><em>VehicleModeEnum</em></td>
 <td><p>0:1</p>
 <p>1:1</p></td>
-<td><p>Mode de transport principal pour la <span class="hl">ZONE D'EMBARQUEMENT</span>. La liste des modes est présentée en 5.15 dans le Profil Éléments Communs.</p>
-<p><span class="hl">Cet attribut est obligatoire dans le cadre du profil</span>.</p></td>
+<td><p>Mode de transport principal pour la <mark>ZONE D'EMBARQUEMENT</mark>. La liste des modes est présentée en 5.15 dans le Profil Éléments Communs.</p>
+<p><mark>Cet attribut est obligatoire dans le cadre du profil.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2119,7 +2102,7 @@ Français de NETEx: éléments communs**:
 <p><em>WaterSubmode</em></p></td>
 <td>0:1</td>
 <td><p>Sous mode associé au mode (caractérise le type d’exploitation). Les sous modes sont des énumérés dont les valeurs sont présentées en 7.2.10.</p>
-<p><span class="hl">Il faut noter le cas particulier du Tram-Train qui, bien qu'étant classé en sous-mode du TRAM, peut aussi être utilisé en sous-mode du Ferré.</span></p></td>
+<p><mark>Il faut noter le cas particulier du Tram-Train qui, bien qu'étant classé en sous-mode du TRAM, peut aussi être utilisé en sous-mode du Ferré.</mark></p></td>
 </tr>
 
 <tr class="odd">
@@ -2159,7 +2142,7 @@ Français de NETEx: éléments communs**:
 <td><em>Entrance</em></td>
 <td><em>::></em></td>
 <td><p>STOP PLACE ENTRANCE. hérite de SITE ENTRANCE.</p>
-<p><span class="hl">NOTE </span><em><strong><span class="hl">StopPlaceEntrance</span></strong></em><span class="hl"> n'utilise pas le </span><em><strong><span class="hl">placeGroup</span></strong></em><span class="hl"> dans le cadre du profil .</span></p></td>
+<p><mark>NOTE : <em><strong>StopPlaceEntrance</strong></em> n'utilise pas le <em><strong>placeGroup</strong></em> dans le cadre du profil.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>GROUP</td>
@@ -2313,7 +2296,7 @@ Aucun champ spécifique utilisé
 <td>1:1</td>
 <td><p>Description de la TOPOGRAPHIC PLACE.</p>
 <p>Le nom de la Zone Administrative est un des attributs de cette structure, ce qui explique son caractère obligatoire.</p>
-<p><em><span class="hl">Note: le nom peut aussi apparaître dans l'attribut </span><strong><span class="hl">name</span></strong><span class="hl"> hérité de </span><strong><span class="hl">GroupOfEntities</span></strong><span class="hl"> où il n'est pas obligatoire. Si les deux noms sont renseignés, ils doivent naturellement être identiques (si ce n'était pas le cas, celui obligatoire du </span><strong><span class="hl">Descriptor</span></strong><span class="hl"> prévaut)</span></em></p></td>
+<p><em><mark>Note : le nom peut aussi apparaître dans l'attribut <strong>name</strong> hérité de <strong>GroupOfEntities</strong> où il n'est pas obligatoire. Si les deux noms sont renseignés, ils doivent naturellement être identiques (si ce n'était pas le cas, celui obligatoire du <strong>Descriptor</strong> prévaut).</mark></em></p></td>
 </tr>
 
 <tr class="even">
@@ -2395,12 +2378,12 @@ Aucun champ spécifique utilisé
 <td><em><strong>ParentTopo­graphic­PlaceRef</strong></em></td>
 <td><em>TopographicPlaceRef</em></td>
 <td>0:1</td>
-<td><p>Référence la zone administrative dans laquelle est incluse celle-ci. <span class="hl">Ce champ doit respecter les règles suivantes :</span></p>
-<p><span class="hl">• une RÉGION n'a pas de parent (voir CountryRef)</span></p>
-<p><span class="hl">• un DÉPARTEMENT est contenu dans une RÉGION</span></p>
-<p><span class="hl">• un GROUPEMENT DE COMMUNES est contenu dans un DÉPARTEMENT (ou éventuellement une région s'il est à cheval sur plusieurs DEPARTEMENTs)</span></p>
-<p><span class="hl">• une VILLE est contenue dans un DÉPARTEMENT (et PAS dans GROUPEMENT DE COMMUNES: voir containedIn plus bas)</span></p>
-<p><span class="hl">• un ARRONDISSEMENT est contenu dans VILLE</span></p></td>
+<td><p>Référence la zone administrative dans laquelle est incluse celle-ci. <mark>Ce champ doit respecter les règles suivantes :</mark></p>
+<p><mark>• une RÉGION n'a pas de parent (voir CountryRef)</mark></p>
+<p><mark>• un DÉPARTEMENT est contenu dans une RÉGION</mark></p>
+<p><mark>• un GROUPEMENT DE COMMUNES est contenu dans un DÉPARTEMENT (ou éventuellement une région s'il est à cheval sur plusieurs DEPARTEMENTs)</mark></p>
+<p><mark>• une VILLE est contenue dans un DÉPARTEMENT (et PAS dans GROUPEMENT DE COMMUNES: voir containedIn plus bas)</mark></p>
+<p><mark>• un ARRONDISSEMENT est contenu dans VILLE</mark></p></td>
 </tr>
 
 <tr class="odd">
@@ -2408,7 +2391,7 @@ Aucun champ spécifique utilisé
 <td><em><strong>containedIn</strong></em></td>
 <td><em>TopographicPlaceRef</em></td>
 <td>0:*</td>
-<td><span class="hl">Ce champs est utilisé pour les VILLEs uniquement et permet d'indiquer que la VILLE fait aussi partie d'un GROUPEMENT DE COMMUNES).</span></td>
+<td><mark>Ce champ est utilisé pour les VILLEs uniquement et permet d'indiquer que la VILLE fait aussi partie d'un GROUPEMENT DE COMMUNES).</mark></td>
 </tr>
 
 </tbody>
@@ -2465,7 +2448,7 @@ utilisant un élément ***TopographicPlaceDescriptor*** (par exemple,
 <td>MultilingualString</td>
 <td>0:1</td>
 <td><p>Nom utilisé pour distinguer le TOPOGRAPHIC PLACE d’autres lieux similaires portant le même nom. Ce texte ne doit pas être inclus dans le nom mais peut être ajouté par les applications en fonction du contexte.</p>
-<p>Le qualificatif doit être dans la même langue que le nom <span class="hl">(Français pour le profil)</span></p></td>
+<p>Le qualificatif doit être dans la même langue que le nom <mark>(Français pour le profil)</mark></p></td>
 </tr>
 
 </tbody>

--- a/NeTEx/elements_communs/index.md
+++ b/NeTEx/elements_communs/index.md
@@ -734,7 +734,7 @@ proposent ces colonnes:
     modification (ceci explique notamment que tous les commentaires soient
     en anglais).
 
-Les textes surlignés en <span class="hl">jaune</span> sont ceux
+Les textes surlignés en <mark>jaune</mark> sont ceux
 présentant une particularité (spécialisation du profil France) par rapport à NeTEx : une
 codification particulière, une restriction d'usage, un changement de cardinalité, etc.
 
@@ -892,11 +892,11 @@ informations de responsabilité (et rôles associés) à une
 <td><em><strong>KeyList</strong></em></td>
 <td><em>KeyList</em></td>
 <td>0:1</td>
-<td><p><span class="hl">Ensemble de couples clé-valeur utilisé pour décrire les identifiants secondaires de l'objet (LIGNE, LIEU D'ARRÊT, ZONE D'EMBARQUEMENT, POINT D’ARRET PLANIFIÉ, COURSE, etc.): c’est-à-dire tel qu'il peut être identifié dans des systèmes tiers: billettique, information voyageur, etc. La clé permet de nommer l'identifiant (et donc de faire référence au système tiers), la valeur étant l'identifiant lui-même.</span></p>
-<p><span class="hl">Cette identification servira principalement d'identification croisée, permettant au fournisseur de retrouver facilement, dans ses systèmes, l'origine de l'objet. </span></p>
-<p><span class="hl">La liste des identifiants secondaires est spécifique à chaque fournisseur.</span></p>
-<p><span class="hl">Voir aussi </span><em><strong><span class="hl">PrivateCode</span></strong></em><span class="hl"> du </span><strong><span class="hl">GroupOfEntities</span></strong><span class="hl"> pour les identifiants alternatifs: les KeyList ne sont à utiliser que s'il y a plusieurs identifiants alternatifs, et si elles sont utilisées, le </span><em><strong><span class="hl">PrivateCode</span></strong></em><span class="hl"> doit impérativement être aussi renseigné.</span></p>
-<p><span class="hl">Il est interdit, dans le profil, d’utiliser le système de clé/valeur pour décrire des informations qui pourraient être fournies avec des attributs NeTEx existants (même s’ils ne sont pas retenus par le profil).</span></p></td>
+<td><p><mark>Ensemble de couples clé-valeur utilisé pour décrire les identifiants secondaires de l'objet (LIGNE, LIEU D'ARRÊT, ZONE D'EMBARQUEMENT, POINT D’ARRET PLANIFIÉ, COURSE, etc.): c’est-à-dire tel qu'il peut être identifié dans des systèmes tiers: billettique, information voyageur, etc. La clé permet de nommer l'identifiant (et donc de faire référence au système tiers), la valeur étant l'identifiant lui-même.</mark></p>
+<p><mark>Cette identification servira principalement d'identification croisée, permettant au fournisseur de retrouver facilement, dans ses systèmes, l'origine de l'objet. </mark></p>
+<p><mark>La liste des identifiants secondaires est spécifique à chaque fournisseur.</mark></p>
+<p><mark>Voir aussi <em><strong>PrivateCode</strong></em> du <strong>GroupOfEntities</strong> pour les identifiants alternatifs: les KeyList ne sont à utiliser que s'il y a plusieurs identifiants alternatifs, et si elles sont utilisées, le <em><strong>PrivateCode</strong></em> doit impérativement être aussi renseigné.</mark></p>
+<p><mark>Il est interdit, dans le profil, d’utiliser le système de clé/valeur pour décrire des informations qui pourraient être fournies avec des attributs NeTEx existants (même s’ils ne sont pas retenus par le profil).</mark></p></td>
 </tr>
 
 <tr class="even">
@@ -947,8 +947,8 @@ informations de responsabilité (et rôles associés) à une
 <td><em>ObjectIdType</em></td>
 <td>1:1</td>
 <td><p>Identifiant unique (et pérenne autant que possible) de l'objet.</p>
-<p><span class="hl">Tous les objets métiers "racine" (c’est-à-dire les objets situés au niveau </span><em><strong><span class="hl">members</span></strong></em><span class="hl"> des FRAME (voir 7.2) doivent impérativement être identifiés. Par contre les objets inclus (au sens XML) dans un un autre objet ne seront généralement pas identifiés (l'identification n'est toutefois pas interdite).</span></p>
-<p><strong><span class="hl">Cette remarque est valable pour la totalité des attributs du DataManagedObject (version, validité, etc. ne sont nécessaires que pour les objets racines).</span></strong></p></td>
+<p><mark>Tous les objets métiers "racine" (c’est-à-dire les objets situés au niveau <em><strong>members</strong></em> des FRAME (voir 7.2) doivent impérativement être identifiés. Par contre les objets inclus (au sens XML) dans un un autre objet ne seront généralement pas identifiés (l'identification n'est toutefois pas interdite).</mark></p>
+<p><strong><mark>Cette remarque est valable pour la totalité des attributs du DataManagedObject (version, validité, etc. ne sont nécessaires que pour les objets racines).</mark></strong></p></td>
 </tr>
 </tbody>
 </table>
@@ -1031,14 +1031,14 @@ informations de responsabilité (et rôles associés) à une
 <td><em>ObjectIdType</em></td>
 <td>0:1</td>
 <td><p>Identifiant d'une ENTITÉ dont celle-ci est dérivée.</p>
-<p><span class="hl">Dans le contexte du profil, ce champ est utilisé </span><strong><span class="hl">uniquement</span></strong><span class="hl"> pour lier des objets pour lesquels on a réalisé une variante fonctionnelle. Typiquement, dans le cas d'une ligne de substitution (voir Profil Réseau) on pourra utiliser le </span><em><strong><span class="hl">derivedFromObjectRef </span></strong></em><span class="hl"> pour la relier à la ligne qu'elle remplace temporairement.</span></p></td>
+<p><mark>Dans le contexte du profil, ce champ est utilisé <strong>uniquement</strong> pour lier des objets pour lesquels on a réalisé une variante fonctionnelle. Typiquement, dans le cas d'une ligne de substitution (voir Profil Réseau) on pourra utiliser le <em><strong>derivedFromObjectRef</strong></em> pour la relier à la ligne qu'elle remplace temporairement.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
 <td><em><strong>compatibleWith­VersionRef</strong></em></td>
 <td><em>VersionIdType</em></td>
 <td>0:1</td>
-<td><p><span class="hl">Cet attribut est utilisé uniquement pour les CADREs DE VERSION (VERSION FRAME).</span></p>
+<td><p><mark>Cet attribut est utilisé uniquement pour les CADREs DE VERSION (VERSION FRAME).</mark></p>
 <p>Indique alors la version de l'instance de CADRE DE VERSION avec laquelle cette version d'objet est compatible. Ce CADRE DE VERSION porte le même identifiant que celui du cadre impliqué dans l'échange courant, mais avec un numero de version différent.</p></td>
 </tr>
 
@@ -1082,7 +1082,7 @@ informations de responsabilité (et rôles associés) à une
 <td><em>xsd:normalizedString</em></td>
 <td>0:1</td>
 <td><p>Type de clé.</p>
-<p><span class="hl">Seule la valeur "ALTERNATE_IDENTIFIER" est reconnue dans le cadre du profil. Tout autre type de type de clé devra être ignoré (sans toutefois générer d'erreur).</span></p></td>
+<p><mark>Seule la valeur "ALTERNATE_IDENTIFIER" est reconnue dans le cadre du profil. Tout autre type de type de clé devra être ignoré (sans toutefois générer d'erreur).</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1140,16 +1140,16 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td>Name</td>
 <td><em>MultilingualString</em></td>
 <td><p>0:1</p>
-<p><span class="hl">1:1</span></p></td>
-<td><p>Nom du groupe d'entité <span class="hl">(du LIEU D'ARRÊT, de la ZONE D'EMBARQUEMENT, de l'ACCÈS, etc.)</span></p>
-<p><span class="hl">Attribut rendu obligatoire dans le cadre de ce profil</span></p></td>
+<p><mark>1:1</mark></p></td>
+<td><p>Nom du groupe d'entité <mark>(du LIEU D'ARRÊT, de la ZONE D'EMBARQUEMENT, de l'ACCÈS, etc.)</mark></p>
+<p><mark>Attribut rendu obligatoire dans le cadre de ce profil</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
 <td><em><strong>ShortName</strong></em></td>
 <td><em>MultilingualString</em></td>
 <td>0:1</td>
-<td>Nom court du groupe d'entité <span class="hl">(du LIEU D'ARRÊT, de la ZONE D'EMBARQUEMENT, de l'ACCÈS, etc.)</span></td>
+<td>Nom court du groupe d'entité <mark>(du LIEU D'ARRÊT, de la ZONE D'EMBARQUEMENT, de l'ACCÈS, etc.)</mark></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1164,45 +1164,45 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td><em>PurposeOfGroupingRef</em></td>
 <td>0:1</td>
 <td><p>But fonctionnel pour lequel des GROUPEMENTs d'éléments sont définis. La FINALITÉ DE GROUPEMENT peut être limitée à un ou plusieurs types d'un objet donné.</p>
-<p><span class="hl">Le champ PurposeofGroupingRef devra systématiquement valoir "groupOfStopPlace" pour les GROUPEs DE LIEUX D'ARRÊT. </span></p>
-<p><span class="hl">Dans le cas des groupes de lignes (GROUP OF LINES, voir Profil Réseau) le </span><em><strong><span class="hl">PurposeofGroupingRef</span></strong></em><span class="hl"> pourra être utilisé pour qualifier les lignes administratives en utilisant la valeur "</span><em><strong><span class="hl">administrativeLine</span></strong></em><span class="hl">"</span></p></td>
+<p><mark>Le champ PurposeofGroupingRef devra systématiquement valoir "groupOfStopPlace" pour les GROUPEs DE LIEUX D'ARRÊT. </mark></p>
+<p><mark>Dans le cas des groupes de lignes (GROUP OF LINES, voir Profil Réseau) le <em><strong>PurposeofGroupingRef</strong></em> pourra être utilisé pour qualifier les lignes administratives en utilisant la valeur "<em><strong>administrativeLine</strong></em>"</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«AK»</td>
 <td><em><strong>PrivateCode</strong></em></td>
 <td><em>PrivateCode</em></td>
 <td>0:1</td>
-<td><p>Code "privé" permettant de gérer une identification spécifique indépendante de l'identification partagée<span class="hl">. Si plusieurs identifiants alternatifs sont nécessaires, on pourra recourir au keyList de DataManagedObject, mais dans cette hypothèse le champ PrivateCode devra impérativement être aussi renseigné (avec l'un des identifiants alternatifs).</span></p>
-<p><span class="hl">Ce champ est utilisé de différente façon suivant le contexte. C'est un simple identifiant alternatif pour les LIEU D'ARRÊT, ZONE D'EMBARQUEMENT, GROUPE DE LIEU et ACCÈS.</span></p>
-<p><span class="hl">Dans le cadre des zones administratives (LIEU TOPOGRAPHIQUE) ce code est utilisé de la façon suivante:</span></p>
+<td><p>Code "privé" permettant de gérer une identification spécifique indépendante de l'identification partagée. <mark>Si plusieurs identifiants alternatifs sont nécessaires, on pourra recourir au keyList de DataManagedObject, mais dans cette hypothèse le champ PrivateCode devra impérativement être aussi renseigné (avec l'un des identifiants alternatifs).</mark></p>
+<p><mark>Ce champ est utilisé de différente façon suivant le contexte. C'est un simple identifiant alternatif pour les LIEU D'ARRÊT, ZONE D'EMBARQUEMENT, GROUPE DE LIEU et ACCÈS.</mark></p>
+<p><mark>Dans le cadre des zones administratives (LIEU TOPOGRAPHIQUE) ce code est utilisé de la façon suivante:</mark></p>
 <ul>
 <li><blockquote>
-<p><span class="hl">Région : code NUTS</span></p>
+<p><mark>Région : code NUTS</mark></p>
 </blockquote></li>
 <li><blockquote>
-<p><span class="hl">Département : code NUTS</span></p>
+<p><mark>Département : code NUTS</mark></p>
 </blockquote></li>
 <li><blockquote>
-<p><span class="hl">Groupement de communes: code Postal</span></p>
+<p><mark>Groupement de communes: code Postal</mark></p>
 </blockquote></li>
 <li><blockquote>
-<p><span class="hl">Ville : code INSEE</span></p>
+<p><mark>Ville : code INSEE</mark></p>
 </blockquote></li>
 <li><blockquote>
-<p><span class="hl">Arrondissement : code INSEE</span></p>
+<p><mark>Arrondissement : code INSEE</mark></p>
 </blockquote></li>
 </ul>
-<p><span class="hl">Note: les codes NUTS peuvent être trouvés <a href="https://eur-lex.europa.eu/eli/reg/2003/1059/2018-01-18">ici</a>.</span></p></td>
+<p><mark>Note: les codes NUTS peuvent être trouvés <a href="https://eur-lex.europa.eu/eli/reg/2003/1059/2018-01-18">ici</a>.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«ctd»</td>
 <td><em><strong>(members)</strong></em></td>
 <td><em>VersionOfObjectRef | GroupMember</em></td>
 <td><p>0:1</p>
-<p><em><strong><span class="hl">spécial</span></strong></em></p></td>
-<td><p><strong><span class="hl">Ce champ est apporté par GeneralGroupOfEntities et n'est utilisé que dans certains cas particuliers :</span></strong></p>
+<p><mark><em><strong>spécial</strong></em></mark></p></td>
+<td><p><mark><strong>Ce champ est apporté par GeneralGroupOfEntities et n'est utilisé que dans certains cas particuliers :</strong></mark></p>
 <ul>
-<li><p><strong><span class="hl">Dans le cadre des GROUPEs DE LIEUX D'ARRÊT, et il est alors obligatoire. Il contient la liste des identifiants des membres des GROUPEs DE LIEUX D'ARRÊT (ce sont donc des identifiants de LIEU D'ARRÊT)</span></strong> </p></li>
+<li><p><mark><strong>Dans le cadre des GROUPEs DE LIEUX D'ARRÊT, et il est alors obligatoire. Il contient la liste des identifiants des membres des GROUPEs DE LIEUX D'ARRÊT (ce sont donc des identifiants de LIEU D'ARRÊT)</strong></mark></p></li>
 </ul></td>
 </tr>
 </tbody>
@@ -1234,7 +1234,7 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td><em>GroupOfPoints</em></td>
 <td>::></td>
 <td><p>ZONE hérite de GROUP OF POINTs (note : le <em><strong>GroupOfPoint</strong></em> n’apporte pas d’autres ajouts au <em><strong>GroupOfEntities</strong></em> que l’attribut <em><strong>members</strong></em> spécialisé pour ne référencer que des points).</p>
-<p><span class="hl">Le champ </span><em><strong><span class="hl"> members </span></strong></em><span class="hl">n’est utilisé que dans le cas particulier du transport à la demande, pour permettre d’identifier les arrêts (POINT D’ARRÊT PLANIFIÉs) d’une zone dans le cas de TAD zonal avec arrêt.</span></p></td>
+<p><mark>Le champ <em><strong>members</strong></em> n’est utilisé que dans le cas particulier du transport à la demande, pour permettre d’identifier les arrêts (POINT D’ARRÊT PLANIFIÉs) d’une zone dans le cas de TAD zonal avec arrêt.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
@@ -1248,7 +1248,7 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td><em><strong>Centroid</strong></em></td>
 <td><em>Point</em></td>
 <td>0:1</td>
-<td><p>Point représentatif de la ZONE (<span class="hl">LIEU D'ARRÊT, ZONE D'EMBARQUEMENT, LIEU TOPOGRAPHIQUE, ACCES, POINT D’ARRÊT PLANIFIÉ, etc.</span>).</p>
+<td><p>Point représentatif de la ZONE (<mark>LIEU D'ARRÊT, ZONE D'EMBARQUEMENT, LIEU TOPOGRAPHIQUE, ACCES, POINT D’ARRÊT PLANIFIÉ, etc.</mark>).</p>
 <p>Ce point n'a pas à être le centre, ou le barycentre, de la zone, mais un point qui la localisera de façon satisfaisante (sur un fond de carte par exemple).</p></td>
 </tr>
 <tr class="even">
@@ -1265,7 +1265,7 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td><em>Projection</em></td>
 <td>0:*</td>
 <td><p>Liste des PROJECTIONs de la ZONE.</p>
-<p><span class="hl">La PROJECTION n’est utilisée que pour permettre de mettre en lien l’offre de transport en commun et une description de l’infrastructure (route, rail, etc.). On référencera donc typiquement un jeu de données OSM, NavTeQ Here, etc.</span></p></td>
+<p><mark>La PROJECTION n’est utilisée que pour permettre de mettre en lien l’offre de transport en commun et une description de l’infrastructure (route, rail, etc.). On référencera donc typiquement un jeu de données OSM, NavTeQ Here, etc.</mark></p></td>
 </tr>
 
 </tbody>
@@ -1310,8 +1310,8 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td><em><strong>Location</strong></em></td>
 <td><em>Location</em></td>
 <td>0:1
-<p><strong><span class="hl">1 :1</span></strong></p></td>
-<td>Localisation du POINT <span class="hl">(Obligatoire dans le profil France, notamment pour les objets de type QUAY et STOP PLACE. Attention, l'attribut n'est pas attendu dans les SCHEDULED STOP POINT)</span></td>
+<p><strong><mark>1:1</mark></strong></p></td>
+<td>Localisation du POINT <mark>(Obligatoire dans le profil France, notamment pour les objets de type QUAY et STOP PLACE. Attention, l'attribut n'est pas attendu dans les SCHEDULED STOP POINT)</mark></td>
 </tr>
 <tr class="odd">
 <td>«»</td>
@@ -1319,10 +1319,10 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td><em>xsd:normalizedString</em></td>
 <td>0:1</td>
 <td><p>Identifiant alternatif du point POINT.</p>
-<p><span class="hl">On utilisera le champ PointNumber pour ordonner des points (par exemple les POINTs D’ARRÊT PLANIFIÉs d’une ligne que l’on veut ordonner sur une fiche horaire), avec la convention suivante :</span></p>
+<p><mark>On utilisera le champ PointNumber pour ordonner des points (par exemple les POINTs D’ARRÊT PLANIFIÉs d’une ligne que l’on veut ordonner sur une fiche horaire), avec la convention suivante :</mark></p>
 <ul>
-<li><p><span class="hl">On privilégiera une valeur purement numérique pour ce champ (avec un classement classique du plus petit au plus grand)</span></p></li>
-<li><p><span class="hl">Si ce n’était pas le cas le classement sera réalisé de façon alphanumérique (et non alphabétique), aussi appelé classement naturel, en intégrant donc une reconnaissance de l’éventuelle partie numérique. (voir </span><a href="http://rosettacode.org/wiki/Natural_sorting"><span class="hl">http://rosettacode.org/wiki/Natural_sorting</span></a><span class="hl"> par exemple)</span></p></li>
+<li><p><mark>On privilégiera une valeur purement numérique pour ce champ (avec un classement classique du plus petit au plus grand)</mark></p></li>
+<li><p><mark>Si ce n’était pas le cas le classement sera réalisé de façon alphanumérique (et non alphabétique), aussi appelé classement naturel, en intégrant donc une reconnaissance de l’éventuelle partie numérique. (voir <a href="http://rosettacode.org/wiki/Natural_sorting">http://rosettacode.org/wiki/Natural_sorting</a> par exemple)</mark></p></li>
 </ul></td>
 </tr>
 
@@ -1332,7 +1332,7 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td><em>Projection</em></td>
 <td>0:*</td>
 <td><p>Projections du POINT.</p>
-<p><span class="hl">La PROJECTION n’est utilisée que pour permettre de mettre en lien l’offre de transport en commun et une description de l’infrastructure (route, rail, etc.). On référencera donc typiquement un jeu de données OSM, NavTeQ Here, etc.</span></p></td>
+<p><mark>La PROJECTION n’est utilisée que pour permettre de mettre en lien l’offre de transport en commun et une description de l’infrastructure (route, rail, etc.). On référencera donc typiquement un jeu de données OSM, NavTeQ Here, etc.</mark></p></td>
 </tr>
 
 </tbody>
@@ -1386,7 +1386,7 @@ spécialisés et adaptés : par exemple des ***RoutePoints*** pour les
 <td><em>DistanceType</em></td>
 <td>0:1</td>
 <td><p>Longueur du TRONÇON (unité en cohérence avec l’unité par défaut des frames, en mètre pour la France naturellement).</p>
-<p><span class="hl">Il ne s'agit pas de la simple distance "à vol d'oiseau" entre les deux extrémités, mais de la distance opérationnelle que l'on souhaite faire porter au TRONÇON, comme la distance qui sera parcourue par un véhicule sur ce TRONÇON par exemple.</span></p></td>
+<p><mark>Il ne s'agit pas de la simple distance "à vol d'oiseau" entre les deux extrémités, mais de la distance opérationnelle que l'on souhaite faire porter au TRONÇON, comme la distance qui sera parcourue par un véhicule sur ce TRONÇON par exemple.</mark></p></td>
 </tr>
 
 <tr class="even">
@@ -1398,18 +1398,18 @@ spécialisés et adaptés : par exemple des ***RoutePoints*** pour les
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
-<td colspan="2"><em><strong><del><span class="hl">projections</span></del></strong></em></td>
+<td colspan="2"><em><strong><del><mark>projections</mark></del></strong></em></td>
 <td></td>
 <td></td>
-<td><p><span class="hl">La PROJECTION n’est utilisée que pour permettre de mettre en lien l’offre de transport en commun et une description de l’infrastructure (route, rail, etc.). On référencera donc typiquement un jeu de données OSM, NavTeQ Here, etc.</span></p>
-<p><span class="hl">Dans le cas des TRONÇONs la projection n’est généralement pas simple un TRONÇON ne se projetant généralement pas sur un unique autre TRONÇON (on aura presque systématiquement un TRONÇON TC à cheval sur N tronçon routier, ou encore l’inverse) : il a donc été fait le choix de ne projeter que les point extrémités du TRONÇON (ces point peuvent se projeter sur un autre point, ou sur un segment).</span></p></td>
+<td><p><mark>La PROJECTION n’est utilisée que pour permettre de mettre en lien l’offre de transport en commun et une description de l’infrastructure (route, rail, etc.). On référencera donc typiquement un jeu de données OSM, NavTeQ Here, etc.</mark></p>
+<p><mark>Dans le cas des TRONÇONs la projection n’est généralement pas simple un TRONÇON ne se projetant généralement pas sur un unique autre TRONÇON (on aura presque systématiquement un TRONÇON TC à cheval sur N tronçon routier, ou encore l’inverse) : il a donc été fait le choix de ne projeter que les point extrémités du TRONÇON (ces point peuvent se projeter sur un autre point, ou sur un segment).</mark></p></td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>
-<td colspan="2"><em><strong><span class="hl">passingThrough</span></strong></em></td>
+<td colspan="2"><em><strong><mark>passingThrough</mark></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Le besoin de points intermédiaires est lié soit à une géométrie complexe (on utilisera alors l’attribut </span><em><strong><span class="hl">LineString</span></strong></em><span class="hl">) soit au fait que, par exemple, un TRONÇON sur un PARCOURS passe par un arrêt sans s’y arrêter, mais on utilisera dans ce cas les éléments du PARCOURS dédiés à la description de cette situation.</span></td>
+<td><mark>Le besoin de points intermédiaires est lié soit à une géométrie complexe (on utilisera alors l’attribut <em><strong>LineString</strong></em>) soit au fait que, par exemple, un TRONÇON sur un PARCOURS passe par un arrêt sans s’y arrêter, mais on utilisera dans ce cas les éléments du PARCOURS dédiés à la description de cette situation.</mark></td>
 </tr>
 <tr class="odd">
 <td colspan="2" rowspan="2">uniquement dans les spécialisations concrètes de <em><strong>Link</strong></em></td>
@@ -1500,7 +1500,7 @@ façon détaillée. C’est, autant que possible, la version simplifiée du
 <td><em>xsd:dateTime</em></td>
 <td>0:1</td>
 <td>Date et heure de début de validité (inclusif)<br />
-<span class="hl">Le </span><em><strong><span class="hl">FromDate</span></strong></em><span class="hl"> est obligatoire dans le cadre du profil (le </span><em><strong><span class="hl">ToDate</span></strong></em><span class="hl"> ne l’est pas, et s’il n’est pas rempli, la validité débute au </span><em><strong><span class="hl">FromDate</span></strong></em><span class="hl"> sans limite de fin.</span></td>
+<mark>Le <em><strong>FromDate</strong></em> est obligatoire dans le cadre du profil (le <em><strong>ToDate</strong></em> ne l’est pas, et s’il n’est pas rempli, la validité débute au <em><strong>FromDate</strong></em> sans limite de fin.</mark></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1536,7 +1536,7 @@ façon détaillée. C’est, autant que possible, la version simplifiée du
 <td><em>DataManagedObject</em></td>
 <td><em>::></em></td>
 <td><p>Inherits from DATA MANAGED OBJECT.</p>
-<p><span class="hl">L’héritage reste naturellement valable, mais aucun des attributs qu’il apporte ne sera utilisé.</span></p></td>
+<p><mark>L’héritage reste naturellement valable, mais aucun des attributs qu’il apporte ne sera utilisé.</mark></p></td>
 </tr>
 
 <tr class="odd">
@@ -1559,7 +1559,7 @@ façon détaillée. C’est, autant que possible, la version simplifiée du
 <td>ObjectRef</td>
 <td>0:1</td>
 <td><p>Référence de l’objet sur lequel porte la CONDITION DE VALIDITÉ.</p>
-<p><span class="hl">Cet attribut n’est utilisé que si la condition de validité est fournie comme un objet indépendant au sein d’une FRAME (voir 7.2). Dans tous les autre cas (la CONDITION DE VALIDITÉ est dans l’arborescence XML d’un objet) c’est le contexte qui fournit cette information, et ce champ sera ignoré.</span> <span class="hl">On n’utilisera les conditions de validité comme un objet indépendant que pour pouvoir les référencer avec un </span><em><strong><span class="hl">WithConditionRef </span></strong></em><span class="hl">(champ suivant)</span></p></td>
+<p><mark>Cet attribut n’est utilisé que si la condition de validité est fournie comme un objet indépendant au sein d’une FRAME (voir 7.2). Dans tous les autre cas (la CONDITION DE VALIDITÉ est dans l’arborescence XML d’un objet) c’est le contexte qui fournit cette information, et ce champ sera ignoré.</mark> <mark>On n’utilisera les conditions de validité comme un objet indépendant que pour pouvoir les référencer avec un <em><strong>WithConditionRef</strong></em>(champ suivant)</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -1567,8 +1567,8 @@ façon détaillée. C’est, autant que possible, la version simplifiée du
 <td>ValidityConditionRef</td>
 <td>0:1</td>
 <td><p>Cet attribut permet de chaîner plusieurs CONDITIONs DE VALIDITÉ qui seront alors logiquement combinées par l’opérateur logique ET.</p>
-<p><span class="hl">On pourra ainsi gérer une période combinée à des exclusions, combiner des périodes et des évènements déclencheurs, etc.</span></p>
-<p><span class="hl">Pour la gestion des exceptions, on exprimera toujours une CONDITION DE VALIDITÉ « principale » et on y associera des exceptions par </span><em><strong><span class="hl">WithConditionRef</span></strong></em><span class="hl"> et non l’inverse. Pour toutes les combinaisons on procédera de même si une CONDITION DE VALIDITÉ « principale » peut être identifiée.</span></p></td>
+<p><mark>On pourra ainsi gérer une période combinée à des exclusions, combiner des périodes et des évènements déclencheurs, etc.</mark></p>
+<p><mark>Pour la gestion des exceptions, on exprimera toujours une CONDITION DE VALIDITÉ « principale » et on y associera des exceptions par <em><strong>WithConditionRef</strong></em> et non l’inverse. Pour toutes les combinaisons on procédera de même si une CONDITION DE VALIDITÉ « principale » peut être identifiée.</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -1634,7 +1634,7 @@ etc.)
 <td>DayTypeRef</td>
 <td>0:*</td>
 <td><p>TYPE DE JOUR pendant lesquels la CONDITIONs DE VALIDITÉ s’applique.</p>
-<p><span class="hl">On n’utilisera pas simultanément et </span><em><strong><span class="hl">operatingDays</span></strong></em><span class="hl"> dans une même CONDITION DE VALIDITÉ.</span></p></td>
+<p><mark>On n’utilisera pas simultanément et <em><strong>operatingDays</strong></em> dans une même CONDITION DE VALIDITÉ.</mark></p></td>
 </tr>
 
 <tr class="even">
@@ -1643,7 +1643,7 @@ etc.)
 <td>TimeBand</td>
 <td>0:*</td>
 <td><p>TRANCHEs HORAIREs pendant lesquelles la CONDITIONs DE VALIDITÉ s’applique.</p>
-<p><span class="hl">Permet essentiellement d’exprimer les heures d’ouverture.</span></p></td>
+<p><mark>Permet essentiellement d’exprimer les heures d’ouverture.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
@@ -1651,7 +1651,7 @@ etc.)
 <td><em>OperatingDay</em></td>
 <td>0:*</td>
 <td><p>Jours d’exploitation pendant lesquels la CONDITIONs DE VALIDITÉ s’applique.</p>
-<p><span class="hl">On n’utilisera pas simultanément et </span><em><strong><span class="hl">operatingDays</span></strong></em><span class="hl"> dans une même CONDITION DE VALIDITÉ.</span></p></td>
+<p><mark>On n’utilisera pas simultanément et <em><strong>operatingDays</strong></em> dans une même CONDITION DE VALIDITÉ.</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -1687,7 +1687,7 @@ etc.)
 <td>ObjectRef</td>
 <td>0:1</td>
 <td><p>Référence (identifiant) de l’objet déclencheur de la validité.</p>
-<p><span class="hl">De façon pratique, plutôt que de réel identifiant d’objet, on utilisera ici des valeurs codifiées dont les valeurs possibles seront précisées dans les spécifications d’interface du système producteur. Par convention on utilisera autant que possible les codes </span><em><strong><span class="hl">reason</span></strong></em><span class="hl">, </span><em><strong><span class="hl">subreason</span></strong></em><span class="hl"> et </span><em><strong><span class="hl">PublicEvent</span></strong></em><span class="hl"> proposés par le service SIRI Situation Exchange.</span></p></td>
+<p><mark>De façon pratique, plutôt que de réel identifiant d’objet, on utilisera ici des valeurs codifiées dont les valeurs possibles seront précisées dans les spécifications d’interface du système producteur. Par convention on utilisera autant que possible les codes <em><strong>reason</strong></em>, <em><strong>subreason</strong></em> et <em><strong>PublicEvent</strong></em> proposés par le service SIRI Situation Exchange.</mark></p></td>
 </tr>
 
 </tbody>
@@ -1724,7 +1724,7 @@ Les informations concernant l'ACCESSIBILITÉ sont utilisées de la même façon 
 <td><em>VersionOfObjectRef</em></td>
 <td>0:1</td>
 <td><p>Référence de l’objet pour lequel on fourni un nom alternatif.</p>
-<p><span class="hl">Cet attribut n’est utilisé que si le nom alternatif est fourni comme un objet indépendant au sein d’une FRAME (voir 7.2). Dans tous les autre cas (le NOM ALTERNATIF est dans l’arborescence XML d’un objet) c’est le contexte qui fournit cette information, et ce champ sera ignoré.</span></p></td>
+<p><mark>Cet attribut n’est utilisé que si le nom alternatif est fourni comme un objet indépendant au sein d’une FRAME (voir 7.2). Dans tous les autre cas (le NOM ALTERNATIF est dans l’arborescence XML d’un objet) c’est le contexte qui fournit cette information, et ce champ sera ignoré.</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1801,9 +1801,8 @@ Paris-Bercy”), alors qu’***AlternativeText*** servira essentiellement
 pour les traductions (par exemple. “en.London”, “fr.Londres”,
 “it.Londra”, “cn.倫敦”, “ge.ლონდონი”, etc).
 
-<span class="hl">Dans le profil, </span>**<span
-class="hl">AlternativeText </span>**<span class="hl">sera toujours
-utilisé comme balise incluse (et non comme élément racine).</span>
+<mark>Dans le profil, **AlternativeText** sera toujours utilisé comme balise
+incluse (et non comme élément racine).</mark>
 
 1.  *AlternativeText – XML Element*
 
@@ -1843,7 +1842,7 @@ utilisé comme balise incluse (et non comme élément racine).</span>
 <td><em>xsd:language</em></td>
 <td><u>0:1</u></td>
 <td><p>Langage utilisé pour cette variante</p>
-<p><span class="hl">« fr » n’est pas accepté dans le profil, </span><strong><span class="hl">AlternativeText</span></strong><span class="hl"> étant réservé aux traductions.</span></p></td>
+<p><mark>« fr » n’est pas accepté dans le profil, <strong>AlternativeText</strong> étant réservé aux traductions.</mark></p></td>
 </tr>
 
 
@@ -1979,17 +1978,17 @@ Il est donc recommandé d'utiliser en priorité le champ `AddressLine1` en n'ind
 de la rue, en évitant d'inclure les noms ou codes des batiments. Ce champ libre permettra dans certains cas d'indiquer
 les informations nécessaire quand aucune adresse n'existe (par exemple un arrêt à un croisement de routes en inter-urbain).
 
-| **Classifi­cation** | **Nom**           | **Type**             |     | **Description**                         |
-|--------------------|-------------------|----------------------|-----|-----------------------------------------|
-|       ::>           | ::>  | *Address*        | 	::> | POSTAL ADDRESS hérite de ADDRESS. |
-|                     | ***AddressLine1***  | *xsd:normalizedString*        | 0:1 | Numéro et rue de l'adresse. Le num du batiment peut également être précisé.  <span class="hl">Ce champ retenu dans le profil France comme porteur de l'information de l'adresse (voir explication ci-dessus) </span> |
-|                     | ***HouseNumber***   | *xsd:normalizedString*        | 0:1 | Numéro du bâtiment sur la voie. Ce champ vient compléter le champ `AddressLine1` |
-|                     | ***Street***        | *xsd:normalizedString*        | 0:1 | Nom et type de voie. Ce champ vient compléter le champ `AddressLine1` |
-|                     | ***BuildingName***  | *xsd:normalizedString*        | 0:1 | Nom du bâtiment. Ce champ vient compléter le champ `AddressLine1` |
-|                     | ***Town***          | *MultilingualString* | 0:1 | Nom de la ville                             |
-|                     | ***PostCode***      | *PostCodeType* | 0:1 | Code Postal                             |
-|                     | ***PostCode­Extension*** | *xsd:normalizedString* | 0:1 | Extension du code postal (avec éventuel cedex ou boite postale)                           |
-|                     | ***PostalRegion***  | *MultilingualString* | 0:1 | Code INSEE. <span class="hl">NOTE : le code INSEE permet aussi de faire la liaison avec la ville ou l'arrondissement (en tant que zone administrative) d'appartenance.</span> |
+| **Classifi­cation** | **Nom**                | **Type**                    |     | **Description**                         |
+|--------------------|-------------------------|-----------------------------|-----|-----------------------------------------|
+| ::>                | ::>                     | *Address* | ::> | POSTAL ADDRESS hérite de ADDRESS. |
+|                    | ***AddressLine1***      | *xsd:normalizedString* | 0:1 | Numéro et rue de l'adresse. Le num du batiment peut également être précisé. <mark>Ce champ retenu dans le profil France comme porteur de l'information de l'adresse (voir explication ci-dessus)</mark> |
+|                    | ***HouseNumber***       | *xsd:normalizedString* | 0:1 | Numéro du bâtiment sur la voie. Ce champ vient compléter le champ `AddressLine1` |
+|                    | ***Street***            | *xsd:normalizedString* | 0:1 | Nom et type de voie. Ce champ vient compléter le champ `AddressLine1` |
+|                    | ***BuildingName***      | *xsd:normalizedString* | 0:1 | Nom du bâtiment. Ce champ vient compléter le champ `AddressLine1` |
+|                    | ***Town***              | *MultilingualString* | 0:1 | Nom de la ville |
+|                    | ***PostCode***          | *PostCodeType* | 0:1 | Code Postal |
+|                    | ***PostCode­Extension*** | *xsd:normalizedString* | 0:1 | Extension du code postal (avec éventuel cedex ou boite postale) |
+|                    | ***PostalRegion***      | *MultilingualString* | 0:1 | Code INSEE. <mark>NOTE : le code INSEE permet aussi de faire la liaison avec la ville ou l'arrondissement (en tant que zone administrative) d'appartenance.</mark> |
 
 
 **Exemple de fourniture d'adresse dans le profil France :**
@@ -2049,8 +2048,8 @@ ou dans une version plus complète :
 <td><em><strong>GisFeatureRef</strong></em></td>
 <td><em>normalizedString</em></td>
 <td></td>
-<td><p><span class="hl">Identification de l'objet correspondant à la voie dans une base spatiale (type PostGIS par exemple) ou dans un SIG.</span></p>
-<p><span class="hl">Cet attribut permettra par exemple d'établir le lien avec une base IGN, Open Street Map, NavTeq, Teleatlas, etc.</span></p></td>
+<td><p><mark>Identification de l'objet correspondant à la voie dans une base spatiale (type PostGIS par exemple) ou dans un SIG.</mark></p>
+<p><mark>Cet attribut permettra par exemple d'établir le lien avec une base IGN, Open Street Map, NavTeq, Teleatlas, etc.</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -2188,7 +2187,7 @@ date proposé par le mécanisme de référence de NeTEx.
 <td><em><strong>created</strong></em></td>
 <td><em>xsd:dateTime</em></td>
 <td>0:1</td>
-<td><span class="hl">Date à laquelle la référence a été créée: ATTENTION il ne s'agit pas ici de la date de création de l'objet, mais bien de la </span><strong><span class="hl">date à laquelle la référence a été créée</span></strong><span class="hl">. Cela permettra, en cas d'absence de mécanisme de version, de retrouver la version de l'objet considérée (dernière version à la date du…).</span></td>
+<td><mark>Date à laquelle la référence a été créée: ATTENTION il ne s'agit pas ici de la date de création de l'objet, mais bien de la <strong>date à laquelle la référence a été créée</strong>. Cela permettra, en cas d'absence de mécanisme de version, de retrouver la version de l'objet considérée (dernière version à la date du…).</mark></td>
 </tr>
 
 <tr class="odd">
@@ -2197,8 +2196,8 @@ date proposé par le mécanisme de référence de NeTEx.
 <td>VersionRef</td>
 <td>0:1</td>
 <td><p>Version de l'objet référencé.</p>
-<p><span class="hl">Si les objets n'ont pas de version, mais que le jeu de donnée en a, on utilisera le CODESPACE en prefixe (ainsi </span><span class="hl">versionRef='TeleAtlas:MapMarker_USA_v04_Data/USA_TPT_2014_09</span><span class="hl">' pourra référer un jeu de données TeleAtlas (en ayant pris soin de créer le CODESPACE TeleAtlas au préalable, sur le principe indiqué ci-dessus).</span></p>
-<p><span class="hl">Le référencement de la version de l'objet n'est naturellement pas obligatoire: si elle est absente on considère qu'il s'agit de la version courante.</span></p>
+<p><mark>Si les objets n'ont pas de version, mais que le jeu de donnée en a, on utilisera le CODESPACE en prefixe (ainsi versionRef='TeleAtlas:MapMarker_USA_v04_Data/USA_TPT_2014_09' pourra référer un jeu de données TeleAtlas (en ayant pris soin de créer le CODESPACE TeleAtlas au préalable, sur le principe indiqué ci-dessus).</mark></p>
+<p><mark>Le référencement de la version de l'objet n'est naturellement pas obligatoire: si elle est absente on considère qu'il s'agit de la version courante.</mark></p>
 <p>Pour les références externe, on procèdera comme indiqué en <em><strong>7.5 -</strong></em> <em><strong>Version des objets et références</strong></em> en precisant la version pointée grace à l’attribut versionRef (par exemple <TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_COMMUN" <strong>versionRef="1.01:FR-NETEX_COMMUN-1.0</strong>">)</p></td>
 </tr>
 <tr class="even">
@@ -2206,7 +2205,7 @@ date proposé par le mécanisme de référence de NeTEx.
 <td><strong>ref</strong></td>
 <td>ObjectRefObjectIdType</td>
 <td>1:1</td>
-<td>Identifiant de l'objet référencé <span class="hl">précédé de son CODESPACE.</span></td>
+<td>Identifiant de l'objet référencé <mark>précédé de son CODESPACE.</mark></td>
 </tr>
 </tbody>
 </table>
@@ -2236,7 +2235,7 @@ date proposé par le mécanisme de référence de NeTEx.
 <td>PointRef</td>
 <td>0:1</td>
 <td><p>POINT projeté.</p>
-<p><span class="hl">Cet attribut n’est utile que si la projection est fournie comme un objet indépendant au sein d’une FRAME (voir 7.2). Dans tous les autres cas (la PROJECTION est dans l’arborescence XML d’un objet) c’est le contexte qui fournit cette information, et ce champ sera ignoré.</span></p></td>
+<p><mark>Cet attribut n’est utile que si la projection est fournie comme un objet indépendant au sein d’une FRAME (voir 7.2). Dans tous les autres cas (la PROJECTION est dans l’arborescence XML d’un objet) c’est le contexte qui fournit cette information, et ce champ sera ignoré.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -2244,8 +2243,8 @@ date proposé par le mécanisme de référence de NeTEx.
 <td>PointRef</td>
 <td>0:1</td>
 <td><p>POINT sur lequel on se projette.</p>
-<p><span class="hl">Dans le contexte des profils NeTEx, il s'agit là d'une référence vers une donnée externe (OSM, Nokia Here (ex Navteq), Tomtom TeleAtlas, IGN, INSPIRE, etc.)</span>.</p>
-<p><span class="hl">La codification respectera les règles décrites ci-dessus pour les références externes.</span></p></td>
+<p><mark>Dans le contexte des profils NeTEx, il s'agit là d'une référence vers une donnée externe (OSM, Nokia Here (ex Navteq), Tomtom TeleAtlas, IGN, INSPIRE, etc.)</mark>.</p>
+<p><mark>La codification respectera les règles décrites ci-dessus pour les références externes.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«FK»</td>
@@ -2289,7 +2288,7 @@ date proposé par le mécanisme de référence de NeTEx.
 <td>ZoneRef</td>
 <td>0:1</td>
 <td><p>ZONE that is being projected.</p>
-<p><span class="hl">Cet attribut n’est utile que si la projection est fournie comme un objet indépendant au sein d’une FRAME (voir 7.2). Dans tous les autre cas (la PROJECTION est dans l’arborescence XML d’un objet) c’est le contexte qui fournit cette information, et ce champ sera ignoré.</span></p></td>
+<p><mark>Cet attribut n’est utile que si la projection est fournie comme un objet indépendant au sein d’une FRAME (voir 7.2). Dans tous les autre cas (la PROJECTION est dans l’arborescence XML d’un objet) c’est le contexte qui fournit cette information, et ce champ sera ignoré.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -2297,8 +2296,8 @@ date proposé par le mécanisme de référence de NeTEx.
 <td>ZoneRef</td>
 <td>0:1</td>
 <td><p>ZONE sur lequel on se projette.</p>
-<p><span class="hl">Dans le contexte des profils NeTEx, il s'agit là d'une référence vers une donnée externe (OSM, Nokia Here (ex Navteq), Tomtom TeleAtlas, IGN, INSPIRE, etc.)</span>.</p>
-<p><span class="hl">La codification respectera les règles décrites ci-dessus pour les références externes.</span></p></td>
+<p><mark>Dans le contexte des profils NeTEx, il s'agit là d'une référence vers une donnée externe (OSM, Nokia Here (ex Navteq), Tomtom TeleAtlas, IGN, INSPIRE, etc.)</mark>.</p>
+<p><mark>La codification respectera les règles décrites ci-dessus pour les références externes.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«FK»</td>
@@ -2550,7 +2549,7 @@ d'OPÉRATEUR et d'AUTORITÉ.
 <td colspan="2"><em><strong>CompanyNumber</strong></em></td>
 <td><em>xsd:normalizedString</em></td>
 <td>0:1</td>
-<td>Numéro d'enregistrement de l'institution <span class="hl">(type code transporteur affecté par l'AO, NAO de la norme 99-502 pour les AOT, etc.)</span></td>
+<td>Numéro d'enregistrement de l'institution <mark>(type code transporteur affecté par l'AO, NAO de la norme 99-502 pour les AOT, etc.)</mark></td>
 </tr>
 
 <tr class="odd">
@@ -2605,7 +2604,7 @@ d'OPÉRATEUR et d'AUTORITÉ.
 <td colspan="2"><em><strong>OrganisationType</strong></em></td>
 <td><em>TypeOfOrganisationEnum</em></td>
 <td><p>0:1</p>
-<p><span class="hl">1:1</span></p></td>
+<p><mark>1:1</mark></p></td>
 <td><p>Type d'organisation codifié:</p>
 <ul>
 <li><p><em><strong>authority</strong></em> : Autorité organisatrice</p></li>
@@ -2630,7 +2629,7 @@ d'OPÉRATEUR et d'AUTORITÉ.
 <td><em>OrganisationPart</em></td>
 <td>0:*</td>
 <td><p>Ensemble des entités constituant ou faisant partie de l'INSTITUTION (UNITÉ ORGANISATIONELLE ou DÉPARTEMENT).</p>
-<p><span class="hl">Seules les UNITÉs ORGANISATIONELLEs seront utilisées dans le cadre des profils NeTEx.</span></p></td>
+<p><mark>Seules les UNITÉs ORGANISATIONELLEs seront utilisées dans le cadre des profils NeTEx.</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -2727,14 +2726,14 @@ de contrôle.
 <td><em>TypeOfOrganisation­PartRef</em></td>
 <td>0:1</td>
 <td><p>Référence le type d'UNITÉ ORGANISATIONNELLE.</p>
-<p><span class="hl">On utilisera la reference comme type, mais sans obligation de créer le TYPE DE VALEUR correspondant.</span></p></td>
+<p><mark>On utilisera la reference comme type, mais sans obligation de créer le TYPE DE VALEUR correspondant.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>
-<td><em><strong><del><span class="hl">Administrative­Zones</span></del></strong></em></td>
+<td><em><strong><del><mark>Administrative­Zones</mark></del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">On passera par le ResponsibilityRoleAssignment si une ZONE ADMINISTRATIVE doit être référencée.</span></td>
+<td><mark>On passera par le ResponsibilityRoleAssignment si une ZONE ADMINISTRATIVE doit être référencée.</mark></td>
 </tr>
 </tbody>
 </table>
@@ -2753,8 +2752,8 @@ L'OPÉRATEUR hérite de l'INSTITUTION, on utilisera un champ
 |                     | ***CountryRef***                                | CountryRef      | 0:1              | Code ISO 3166-1 correspondant à la nationalité de l’exploitant |
 |                     | Address                                         | PostalAddress   | 0:1              | Postal ADDRESS of ORGANISATION.                                |
 |                     | PrimaryMode                                     | VehicleModeEnum | 0:1              | Mode de tranport principal de l'opérateur (s'il en a un)       |
-|                     | CustomerService­ContactDetails                  |                 |                  | <span class="hl">Voir ContactDetails d'ORGANISATION.</span>  |
-|                     | ***~~<span class="hl">departments</span>~~*** |                 |                  | <span class="hl">Voir Parts d'ORGANISATION.</span>           |
+|                     | CustomerService­ContactDetails                  |                 |                  |<mark>Voir ContactDetails d'ORGANISATION.</mark>  |
+|                     | ***~~<mark>departments</mark>~~*** |                 |                  | <mark>Voir Parts d'ORGANISATION.</mark>           |
 
 ### Autorités
 
@@ -2820,7 +2819,7 @@ jour, etc.).
 <td><em>VersionedChild</em></td>
 <td></td>
 <td><p>RESPONSIBILITY ROLE hérite de VERSIONED CHILD.</p>
-<p><span class="hl">Non utilisé quand inclus comme roles de </span><em><strong><span class="hl">ResponsabilitySet</span></strong><span class="hl"> (l’inclusion est la solution retenue par le profil)</span></em></p></td>
+<p><mark>Non utilisé quand inclus comme roles de <em><strong>ResponsabilitySet</strong> (l’inclusion est la solution retenue par le profil)</em></mark></p></td>
 </tr>
 
 <tr class="even">
@@ -2865,7 +2864,7 @@ jour, etc.).
 <td><em>TypeOfResponsibility RoleRef</em></td>
 <td></td>
 <td><p>Référence à un type de responsabilité.</p>
-<p><span class="hl">On utilisera notamment ce champ pour référencer un type de contrat quand cela est nécessaire.</span></p></td>
+<p><mark>On utilisera notamment ce champ pour référencer un type de contrat quand cela est nécessaire.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -2931,7 +2930,7 @@ jour, etc.).
 <td><em><strong>PublicCode</strong></em></td>
 <td><em>xsd:normalizedString</em></td>
 <td>1:1</td>
-<td>Code publique de la NOTE <span class="hl">(numéro de renvoi sur la fiche horaire par exemple)</span></td>
+<td>Code publique de la NOTE <mark>(numéro de renvoi sur la fiche horaire par exemple)</mark></td>
 </tr>
 
 
@@ -2941,20 +2940,20 @@ jour, etc.).
 <td><em>TypeOfNoticeRef</em></td>
 <td>1:1</td>
 <td><p>Type de NOTE.</p>
-<p><span class="hl">On pourra ainsi catégoriser les NOTEs, par exemple:</span></p>
+<p><mark>On pourra ainsi catégoriser les NOTEs, par exemple :</mark></p>
 <ul>
-<li><p><span class="hl">Exception de circulation (sauf…)</span></p></li>
-<li><p><span class="hl">Restriction de circulation (ne circule que …..)</span></p></li>
-<li><p><span class="hl">Etc.</span></p></li>
+<li><p><mark>Exception de circulation (sauf…)</mark></p></li>
+<li><p><mark>Restriction de circulation (ne circule que …..)</mark></p></li>
+<li><p><mark>Etc.</mark></p></li>
 </ul>
-<p><span class="hl">Ces codes sont ouverts et sont définis par le producteur des données qui en précisera les valeurs possibles dans sa spécification d'interface</span>.</p></td>
+<p><mark>Ces codes sont ouverts et sont définis par le producteur des données qui en précisera les valeurs possibles dans sa spécification d'interface.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
-<td><em><strong><del><span class="hl">CanBeAdvertised</span></del></strong></em></td>
+<td><em><strong><del><mark>CanBeAdvertised</mark></del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Dans le cadre des profils NeTEx, toutes les notes sont à vocation d'information voyageur et donc publiques. </span></td>
+<td><mark>Dans le cadre des profils NeTEx, toutes les notes sont à vocation d'information voyageur et donc publiques.</mark></td>
 </tr>
 
 <tr class="odd">
@@ -2997,7 +2996,7 @@ jour, etc.).
 <td>ParentRef</td>
 <td></td>
 <td></td>
-<td><span class="hl">Les variantes seront toujours exprimées au sein de la NOTE elle-même.</span></td>
+<td><mark>Les variantes seront toujours exprimées au sein de la NOTE elle-même.</mark></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -3029,10 +3028,9 @@ attributs retenus y sont présentés (l'affectation est très paramétrable,
 mais la grande majorité des attributs ne sont pas retenus dans le
 profil).
 
-<span class="hl">Les NoticeAssignments doivent être intégré en ligne à
+<mark>Les NoticeAssignments doivent être intégré en ligne à
 l'élément annoté et non placé séparément. Ils peuvent faire référence à
-une NOTICE déjà définie dans un NOTICE ASSIGNMENT antérieur</span><span
-class="hl">.</span>
+une NOTICE déjà définie dans un NOTICE ASSIGNMENT antérieur.</mark>
 
 <div class="table-title">Notice Assignment – Element</div>
 
@@ -3098,7 +3096,7 @@ class="hl">.</span>
 <td><em><u>Notice</u></em></td>
 <td>0:1</td>
 <td><p>Description de la NOTE elle même.</p>
-<p><span class="hl">On préférera toujours </span><em><strong><span class="hl">Notice</span></strong></em><span class="hl"> à </span><em><strong><span class="hl">NoticeRef</span></strong></em><span class="hl"> (utilisez uniquement </span><em><strong><span class="hl">NoticeRef</span></strong></em><span class="hl"> pour les NOTEs partagés).</span></p></td>
+<p><mark>On préférera toujours <em><strong>Notice</strong></em> à <em><strong>NoticeRef</strong></em> (utilisez uniquement <em><strong>NoticeRef</strong></em> pour les NOTEs partagés).</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -3166,7 +3164,7 @@ class="hl">.</span>
 <td>xsd:date</td>
 <td>1:1</td>
 <td><p>Date calendaire de la JOURNÉE D'EXPLOITATION.</p>
-<p><span class="hl">Il s'agit ici du jour calendaire où démarre la JOURNÉE D'EXPLOITATION, l'heure de début et la durée de la journée étant précisées par les autres paramètres.</span></p></td>
+<p><mark>Il s'agit ici du jour calendaire où démarre la JOURNÉE D'EXPLOITATION, l'heure de début et la durée de la journée étant précisées par les autres paramètres.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -3174,7 +3172,7 @@ class="hl">.</span>
 <td>CalendarRef</td>
 <td>0:1</td>
 <td><p>CALENDRIER DE SERVICE auquel appartient la JOURNÉE D'EXPLOITATION.</p>
-<p><span class="hl">Note: une même journée calendaire peut être couverte par différentes JOURNÉE D'EXPLOITATION (pour différents exploitants, ou différentes modalités d'exploitation, comme par exemple NOCTILIEN (bus de nuit à Paris) et bus RATP). On recommandera toutefois dans ce cas d'affecter ces jours "redondants" à différents CALENDRIERs DE SERVICE.</span></p></td>
+<p><mark>Note : une même journée calendaire peut être couverte par différentes JOURNÉE D'EXPLOITATION (pour différents exploitants, ou différentes modalités d'exploitation, comme par exemple NOCTILIEN (bus de nuit à Paris) et bus RATP). On recommandera toutefois dans ce cas d'affecter ces jours "redondants" à différents CALENDRIERs DE SERVICE.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -3199,7 +3197,7 @@ class="hl">.</span>
 <td>xsd:duration</td>
 <td>1:1</td>
 <td><p>Durée de la JOURNÉE D'EXPLOITATION.</p>
-<p><span class="hl">Une JOURNÉE D'EXPLOITATION peut durer plus de 24h (pas de limite supérieure).</span></p></td>
+<p><mark>Une JOURNÉE D'EXPLOITATION peut durer plus de 24h (pas de limite supérieure).</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -3234,7 +3232,7 @@ disponible au travers de son héritage de *DataManagedObject.*
 <td><em>DataManagedObject</em></td>
 <td>::></td>
 <td><p>DAY TYPE hérite de DATA MANAGED OBJECT.</p>
-<p><span class="hl">On utilisera le </span><em><strong><span class="hl">ValidBetween</span></strong></em><span class="hl"> pour une éventuelle limitation de période</span></p></td>
+<p><mark>On utilisera le <em><strong>ValidBetween</strong></em> pour une éventuelle limitation de période</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -3258,7 +3256,7 @@ disponible au travers de son héritage de *DataManagedObject.*
 <td>xsd:time</td>
 <td>0:1</td>
 <td><p>Heure de début de validité dans le TYPE DE JOUR.</p>
-<p><span class="hl">Exclusif avec <em><strong>timebands</strong></em></span></p></td>
+<p><mark>Exclusif avec <em><strong>timebands</strong></em></mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -3266,7 +3264,7 @@ disponible au travers de son héritage de *DataManagedObject.*
 <td>xsd:duration</td>
 <td>0:1</td>
 <td><p>Durée du TYPE DE JOUR.</p>
-<p><span class="hl">Exclusif avec <em><strong>timebands</strong></em></span></p></td>
+<p><mark>Exclusif avec <em><strong>timebands</strong></em></mark></p></td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
@@ -3303,8 +3301,8 @@ disponible au travers de son héritage de *DataManagedObject.*
 <td>Timeband</td>
 <td>0:*</td>
 <td><p>TRANCHEs HORAIREs du TYPE DE JOUR</p>
-<p><span class="hl">On utilisera ces TRANCHEs HORAIREs uniquement si elles sont multiples (par exemple "</span><em><span class="hl">de 9h à 12h30 et de 14h à 18h30</span></em><span class="hl">") sinon on utilisera <em><strong>EarliestTime</em></strong> et <em><strong>DayLength</em></strong>.</span></p>
-<p><span class="hl">Exclusif avec <em><strong>EarliestTime</strong></em> et <em><strong>DayLength</strong></em></span></p></td>
+<p><mark>On utilisera ces TRANCHEs HORAIREs uniquement si elles sont multiples (par exemple "<em>de 9h à 12h30 et de 14h à 18h30</em>") sinon on utilisera <em><strong>EarliestTime</strong></em> et <em><strong>DayLength</strong></em>.</mark></p>
+<p><mark>Exclusif avec <em><strong>EarliestTime</strong></em> et <em><strong>DayLength</strong></em>.</mark></p>
 </td>
 </tr>
 </tbody>
@@ -3398,7 +3396,7 @@ disponible au travers de son héritage de *DataManagedObject.*
 <td>TideEnum</td>
 <td>0:4</td>
 <td><p>Type de marée de la PROPRIÉTÉ DE JOUR.</p>
-<p><span class="hl">Attention, cette classification restreint à une partie de la journée (marée haute, etc.).</span></p></td>
+<p><mark>Attention, cette classification restreint à une partie de la journée (marée haute, etc.).</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -3598,11 +3596,9 @@ nouveau CALENDRIER DE SERVICE).
 |                     | b                   | ***FromDate*** | dateTime            | 1:1             | Date calendaire de début                            |
 |                     | b                   | ***ToDate***   | dateTime            | 1:1             | Date calendaire de fin                              |
 
-<span class="hl">Note : </span>***<span class="hl">U</span><span
-class="hl">icOperatingPeriod</span>***<span class="hl"> sera toujours
-utilisé dans le contexte du profil, afin de rendre le ValidDayBits
-obligatoire (chaîne de bits, une pour chaque jour de la période: qu'elle
-soit valide ou non le jour).</span>
+<mark>Note : ***UicOperatingPeriod*** sera toujours utilisé dans le contexte du
+profil, afin de rendre le ValidDayBits obligatoire (chaîne de bits, une pour
+chaque jour de la période: qu'elle soit valide ou non le jour).</mark>
 
 <div class="table-title">UicOperatingPeriod – Element</div>
 
@@ -3692,11 +3688,11 @@ etc.).
 
 | **Classifi­cation** | **Name**                    | **Type**               | **Cardin­ality** | **Description**                                                                                                                                                                                                                                                       |
 |---------------------|-----------------------------|------------------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|                     | ***Colour***                | *ColourValue*          | 0:1              | Couleur <span class="hl">(format RVB)</span>                                                                                                                                                                                                                        |
+|                     | ***Colour***                | *ColourValue*          | 0:1              | Couleur <mark>(format RVB)</mark>                                                                                                                                                                                                                        |
 |                     | ***ColourName***            | *xsd:normalizedString* | 0:1              | Nom de la couleur                                                                                                                                                                                                                                                     |
 |                     | ***BackGroundColour***      | *ColourValueType*      | 0:1              | Valeur RVB de la couleur de fond (par exemple la couleur de la ligne de transport)                                                                                                                                                                                    |
 |                     | ***BackgroundColour­Name*** | *xsd:String*           | 0:1              | Nom de la couleur de fond dans le *ColourSystem*.                                                                                                                                                                                                                     |
-|                     | ***TextColour***            | *ColourValue*          | 0:1              | Couleur du texte <span class="hl">(format RVB)</span>                                                                                                                                                                                                               |
+|                     | ***TextColour***            | *ColourValue*          | 0:1              | Couleur du texte <mark>(format RVB)</mark>                                                                                                                                                                                                               |
 |                     | ***TextColourName***        | *xsd:normalizedString* | 0:1              | Nom de la couleur du texte                                                                                                                                                                                                                                            |
 |                     | TextFont                    | *xsd:normalizedString* | 0:1              | Identifiant de la police de caractère                                                                                                                                                                                                                                 |
 |                     | ***TextFontName***          | *xsd:normalizedString* | 0:1              | Nom de la police de caractère                                                                                                                                                                                                                                         |
@@ -3786,7 +3782,7 @@ spécifiques sont décrits dans les lignes ci-dessous.
 <td><em><strong>Publication­Request</strong></em></td>
 <td><em>PublicationRequestStructure</em></td>
 <td>0:1</td>
-<td>Description de la requête ayant donné lieu à la publication. <span class="hl">Ce champ ne sera utilisé que dans le cadre d’une réponse dans le contexte d’un appel de web service (voir 8.2).</span></td>
+<td>Description de la requête ayant donné lieu à la publication. <mark>Ce champ ne sera utilisé que dans le cadre d’une réponse dans le contexte d’un appel de web service (voir 8.2).</mark></td>
 </tr>
 <tr class="odd">
 <td><em><strong>Publication­RefreshInterval</strong></em></td>
@@ -3833,10 +3829,10 @@ Notez que ces conditions de validité du VERSION FRAME ne doivent pas
 être confondues avec **contentValidityConditions** qui sont des
 conditions de validité plus spécifiques qui s'appliquent à plusieurs
 éléments dans le cadre (conditions de validité partagées qui seront
-référencées par les objets eux même). <span class="hl">Dans le cadre du
+référencées par les objets eux même). <mark>Dans le cadre du
 profil, les conditions de validité du VERSION FRAME viennent limiter la
 validité des objets (un objet n’est plus considéré comme valide avant ou
-après la période de la FRAME qui le contient).</span>
+après la période de la FRAME qui le contient).</mark>
 
 ***VersionFrame*** lui-même est abstrait : NeTEx fournit un ensemble de
 cadres « spécifiques » spécialisés à des fins spécifiques (ServiceFrame,
@@ -3904,7 +3900,7 @@ de CADRE spécifique pour chaque partie du profil France (voir plus bas).
 <td><em>TypeOfFrameRef</em></td>
 <td>0:1</td>
 <td><p>Référence au TYPE OF VERSION FRAME utilisé.</p>
-<p><span class="hl">Imposé à NETEX_COMMUN, NETEX_ARRET, NETEX_LIGNE, NETEX_RESEAU, NETEX_HORAIRE, NETEX_CALENDRIER, NETEX_TARIF pour les GeneralFrame et pour les CompositeFrame on utilisera NETEX_FRANCE, NETEX_LIGNE ou NETEX_N_LIGNE.</span> </p></td>
+<p><mark>Imposé à NETEX_COMMUN, NETEX_ARRET, NETEX_LIGNE, NETEX_RESEAU, NETEX_HORAIRE, NETEX_CALENDRIER, NETEX_TARIF pour les GeneralFrame et pour les CompositeFrame on utilisera NETEX_FRANCE, NETEX_LIGNE ou NETEX_N_LIGNE.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«FK»</td>
@@ -3920,8 +3916,8 @@ de CADRE spécifique pour chaque partie du profil France (voir plus bas).
 <td><em>Version</em></td>
 <td>0:*</td>
 <td><p>CODESPACEs utilisé dans le CADRE DE VERSION. Normalement, il y en a au moins un. Une valeur par défaut peut être précisée par le <em><strong>FrameDefaults</strong>.</em></p>
-<p><span class="hl">NOTE </span><span class="hl">Le </span><em><strong><span class="hl">codespace</span></strong></em><span class="hl"> est utilisé par le profil, et il est spécifié par le </span><em><strong><span class="hl">FrameDefaults</span></strong>.</em></p>
-<p><span class="hl">Voir ci-dessous</span></p></td>
+<p><mark>NOTE : Le <em><strong>codespace</strong></em> est utilisé par le profil, et il est spécifié par le <em><strong>FrameDefaults</strong></em>.</mark></p>
+<p><mark>Voir ci-dessous</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
@@ -3944,7 +3940,7 @@ de CADRE spécifique pour chaque partie du profil France (voir plus bas).
 <td><em><strong>content­ValidityConditions</strong></em></td>
 <td><em>ValidityCondition</em></td>
 <td>0:*</td>
-<td>CONDITIONS DE VALIDITE partagées par les différents éléments contenus dans le CADRE.<span class="hl"> On utilisera uniquement le </span><em><strong><span class="hl">ValidBetween</span></strong></em><span class="hl"> comme indiqué en 6.9)</span></td>
+<td>CONDITIONS DE VALIDITE partagées par les différents éléments contenus dans le CADRE. <mark>On utilisera uniquement le <em><strong>ValidBetween</strong></em> comme indiqué en 6.9</mark></td>
 </tr>
 </tbody>
 </table>
@@ -3966,8 +3962,8 @@ de CADRE spécifique pour chaque partie du profil France (voir plus bas).
 |                     | ***DefaultLocale***                | *Locale*               | 0:1 | Valeur de LOCALE par défaut (pour tous les éléments qui ne le précisent pas)                     |
 |                     | ***Default­LocationSystem***       | *xsd:normalizedString* | 0:1 | Système de localisation par défaut (pour tous les éléments qui ne le précisent pas)              |
 
-<span class="hl">Dans le cadre du profil les distances et les longueurs sont par défaut
-exprimées en mètres (*SystemOfUnits* ayant une valeur *SiMetres*) et les sommes d’argent en Euros.</span>
+<mark>Dans le cadre du profil les distances et les longueurs sont par défaut
+exprimées en mètres (*SystemOfUnits* ayant une valeur *SiMetres*) et les sommes d’argent en Euros.</mark>
 
 <div class="table-title">TypeOfFrame – Élément</div>
 
@@ -3995,7 +3991,7 @@ exprimées en mètres (*SystemOfUnits* ayant une valeur *SiMetres*) et les somme
 <td><em>TypeOfValueDataManagedObject</em></td>
 <td><em>::>::></em></td>
 <td><p>TYPE OF FRAME hérite de TYPE OF VALUE.</p>
-<p><span class="hl">L'Id est imposé à NETEX_</span><span class="hl"> </span><span class="hl">RESEAU</span></p></td>
+<p><mark>L'Id est imposé à NETEX_RESEAU</mark></p></td>
 </tr>
 
 
@@ -4111,19 +4107,16 @@ exemples ci-dessus).
 
 ### Codification des identifiants
 
-<span class="hl">L’objectif d’une codification étant de s’assurer de
-l’unicité (</span>**<span class="hl">au niveau
-national</span>**<span class="hl">) et de la pérennité de
-l’identifiant. </span>**<span class="hl">Toute solution autre,
-permettant d’assurer une unicité et une pérennité de l’identifiant est
-valable</span>**<span class="hl">. En particulier, si un référentiel de
+<mark>L’objectif d’une codification étant de s’assurer de
+l’unicité (**au niveau national**) et de la pérennité de
+l’identifiant. **Toute solution autre, permettant d’assurer une unicité et une
+pérennité de l’identifiant est valable**. En particulier, si un référentiel de
 données (arrêts, lignes, etc.) propose des identifiants uniques et
 pérennes, mais avec une structure très différente, cela est tout à fait
-acceptable ! </span>**<span class="hl">Il est par contre impératif que
-l’identifiant d’un objet soit strictement le même quel que soit le flux
-de données utilisé</span>**<span class="hl"> (SIRI, NeTEx, tous
-profils confondus, et même GTFS ou tout autre format qui pourrait être
-utilisé pour l’échange de données).</span>
+acceptable ! **Il est par contre impératif que l’identifiant d’un objet soit
+strictement le même quel que soit le flux de données utilisé** (SIRI, NeTEx,
+tous profils confondus, et même GTFS ou tout autre format qui pourrait être
+utilisé pour l’échange de données).</mark>
 
 **NOTE IMPORTANTE** : la technique de construction proposée ici a pour
 vocation d’assurer l’unicité de l’identifiant, mais en aucun cas
@@ -4136,24 +4129,23 @@ suivante pour tous les identifiants:
 
 `[Fournisseur]:[type d'objet]:[typeObjetDétaillé]:[identifiantTechnique]:LOC`
 
-<span class="hl">
+<mark>
 Si un objet a déjà été identifié dans le cadre d’un
 échange SIRI, on conservera naturellement son identifiant.
-</span>
+</mark>
 
-<span class="hl">Si l’objet n’a encore jamais été échangé, dans le
+<mark>Si l’objet n’a encore jamais été échangé, dans le
 contexte des profils NeTEx, en dehors des arrêt (présenté ci-dessous) la
-codification suivante est proposée :</span>
+codification suivante est proposée :</mark>
 
--   <span class="hl">`[Fournisseur]`</span> : <span class="hl"> est remplacé par le CODESPACE (et peut être complété
-    par le </span><span class="hl">`DataSourceRef`</span><span class="hl"> de </span><span class="hl">`EntityInVersion`</span><span class="hl">)</span>
+-   <mark>`[Fournisseur]` : est remplacé par le CODESPACE (et peut être complété
+    par le `DataSourceRef` de `EntityInVersion`)</mark>
 
--   <span class="hl">`[type d'objet]`</span> : <span class="hl">
-    classe de l'objet sous la forme du nom du tag XML qui le porte</span>
+-   <mark>`[type d'objet]` : classe de l'objet sous la forme du nom du tag XML qui le porte</mark>
 
--   <span class="hl">`[identifiantTechnique]`</span><span class="hl">: est naturellement conservé</span>
+-   <mark>`[identifiantTechnique]` : est naturellement conservé</mark>
 
--   <span class="hl">`LOC` : est conservé
+-   <mark>`LOC` : est conservé
     pour permettre de préciser que l'identifiant a été défini de façon
     locale entre les parties engagées dans l'échange, et qu'il ne fait
     donc pas partie du référentiel partagé (régional, national, etc.)
@@ -4161,116 +4153,89 @@ codification suivante est proposée :</span>
     l'identifiant est local. Pour les objets faisant partie de
     référentiels partagés on peut le remplacer par un
     `[NomAttributaire]` qui le nom (ou code) du système référentiel utilisé
-    pour attribuer l’identifiant.</span>
+    pour attribuer l’identifiant.</mark>
 
-<span class="hl">La codification retenue est donc: </span>
+<mark>La codification retenue est donc : </mark>
 
-<span class="hl">`[CODESPACE]:[type d'objet]:[identifiantTechnique]:[LOC ou Nom attributaire]`</span>
+<mark>`[CODESPACE]:[type d'objet]:[identifiantTechnique]:[LOC ou Nom attributaire]`</mark>
 
-<span class="hl">Exemple `RATP-I2V:JourneyPattern:2354345:LOC` ou `IDFM:Line:345:CODIFLIGNE` ou `STIF-CODIFLIGNE:Line:C00001:`</span>
+<mark>Exemple `RATP-I2V:JourneyPattern:2354345:LOC` ou `IDFM:Line:345:CODIFLIGNE` ou `STIF-CODIFLIGNE:Line:C00001:`</mark>
 
-<span class="hl">Note : par convention, on conserve les
-"</span>**<span class="hl">:</span>**<span class="hl">" de fin même
+<mark>Note : par convention, on conserve les "**:**" de fin même
 s’il n’y a pas de valeur \[NomAttributaire\] ou LOC (même si, encore une
 fois, l’analyse du contenu d’un identifiant est plus que fortement
 déconseillée, et d’autres structures peuvent être utilisée, en fonction
 des systèmes attributaires, pour peu que l’unicité soit conservée au
-niveau national.</span>
+niveau national.</mark>
 
 ### Codification des identifiants d'arrêt
 
-<span class="hl">Les arrêts sont un cas particulier et donneront lieu à
-une codification spécifique. La forme actuellement envisagée étant
-</span>**<span class="hl">\[Code PAYS\]:\[Code commune INSEE\]:\[Type
+<mark>Les arrêts sont un cas particulier et donneront lieu à une codification
+spécifique. La forme actuellement envisagée étant **\[Code PAYS\]:\[Code commune INSEE\]:\[Type
 d’objet\]:\[Code arrêt spécifique\]:\[Code émetteur du code technique ou
-LOC\]</span>**<span class="hl">, on aura donc :</span>
+LOC\]**, on aura donc :</mark>
 
--   **<span class="hl">\[Code PAYS\]</span>**<span class="hl">:
+-   <mark>**\[Code PAYS\]** :
     Identifiant du Pays en respectant la norme ISO 3166-1 (voir:
-    </span>[<span
-    class="hl">www.iso.org/iso-3166-country-codes.html</span>](https://www.iso.org/iso-3166-country-codes.html)<span
-    class="hl">, </span>**<span class="hl">FR</span>**<span
-    class="hl"> pour la France ).</span>
+    [www.iso.org/iso-3166-country-codes.html](https://www.iso.org/iso-3166-country-codes.html), **FR** pour la France ).</mark>
 
--   **<span class="hl">\[Code commune INSEE\]</span>**<span
-    class="hl">: 5 caractères (exemple : 78297 pour Guyancourt), 2
+-   <mark>**\[Code commune INSEE\]** : 5 caractères (exemple : 78297 pour Guyancourt), 2
     caractères pour le département et 3 pour la commune elle-même en
     France métropolitaine et 3 caractères pour le département et 2
-    pour la commune elle-même pour l’outre-mer.</span>  
-    <span class="hl">Ce code commune pourra, de façon optionnelle, être
+    pour la commune elle-même pour l’outre-mer.
+    Ce code commune pourra, de façon optionnelle, être
     complété par le numéro d’arrondissement de commune précédé d’un «-»
     (tiret, ASCII code 45) codé sur un ou deux caractères
-    numériques.</span>  
-    <span class="hl">En cas de mise à jour du code commune par l’INSEE,
+    numériques.
+    En cas de mise à jour du code commune par l’INSEE,
     par souci de pérennité de l’identifiant, on conservera le code
     attribué initialement (pas de suivi d’un éventuel changement de
-    codification INSEE donc).</span>
+    codification INSEE donc).</mark>
 
--   **<span class="hl">\[Type d’objet\]: ZE</span>**<span class="hl">
-    (ZONE D’EMBARQUEMENT), </span>**<span
-    class="hl">LMO</span>**<span class="hl"> (LIEU D’ARRET MONOMODAL),
-    </span>**<span class="hl">PM</span>**<span class="hl"> (POLE
-    MONOMODAL), </span>**<span class="hl">LMU</span>**<span
-    class="hl"> (LIEU D’ARRET MUTIMODAL), </span>**<span
-    class="hl">AC</span>**<span class="hl"> (ACCES)</span>**<span
-    class="hl"> </span>**
+-   <mark>**\[Type d’objet\]** : **ZE** (ZONE D’EMBARQUEMENT),
+    **LMO** (LIEU D’ARRET MONOMODAL),
+    **PM** (POLE MONOMODAL),
+    **LMU** (LIEU D’ARRET MUTIMODAL),
+    **AC** (ACCES)</mark>
 
--   **<span class="hl">\[Code arrêt spécifique\]: </span>**<span
-    class="hl">code technique libre</span>**<span class="hl">
-    </span>**
+-   <mark>**\[Code arrêt spécifique\]** : code technique libre</mark>
 
--   **<span class="hl">\[Code émetteur du code technique ou LOC\] :
-    </span>**<span class="hl">Identifiant de l’attributeur de code
+-   <mark>**\[Code émetteur du code technique ou LOC\]** :
+    Identifiant de l’attributeur de code
     technique centralisé s’il y en a un et LOC sinon. Ci-dessous
-    quelques pistes pour identifier l’attributaire</span>
+    quelques pistes pour identifier l’attributaire</mark>
 
-    -   <span class="hl">Si c’est une région : code NUTS
-        (</span>[<span
-        class="hl">https://eur-lex.europa.eu/eli/reg/2003/1059/2018-01-18</span>](https://eur-lex.europa.eu/eli/reg/2003/1059/2018-01-18)<span
-        class="hl">) sans le FR, précédé de </span>**<span
-        class="hl">NUTS</span>**<span class="hl"> (</span>**<span
-        class="hl">NUTS714</span>**<span class="hl"> pour Isère par
-        exemple)</span>
+    -   <mark>Si c’est une région : code NUTS
+        ([https://eur-lex.europa.eu/eli/reg/2003/1059/2018-01-18](https://eur-lex.europa.eu/eli/reg/2003/1059/2018-01-18))
+        sans le FR, précédé de **NUTS** (**NUTS714** pour Isère par exemple)</mark>
 
-    -   <span class="hl">Si c’est une AOT : code </span>**<span
-        class="hl">NAO</span>**<span class="hl"> de la norme NF-9950
-        précédé de NAO (</span>**<span
-        class="hl">NAO17</span>**<span class="hl"> pour Blefort par
-        exemple)</span>
+    -   <mark>Si c’est une AOT : code **NAO** de la norme NF-9950 précédé de NAO
+        (**NAO17** pour Belfort par exemple)</mark>
 
-    -   <span class="hl">Si un attributeur national est national est
-        créé, il prendra le code </span>**<span
-        class="hl">FR</span>**
+    -   <mark>Si un attributeur national est national est
+        créé, il prendra le code **FR**</mark>
 
-    -   <span class="hl">Si le code technique est attribué par le
-        système local</span>**<span class="hl"> : </span>**<span
-        class="hl">code </span>**<span class="hl">LOC</span>**<span
-        class="hl"> (comme pour le profil SIRI) . Note : un code
-        </span>**<span class="hl">LOC</span>**<span class="hl"> est
-        à considérer comme à priori temporaire, en attente de la mise en
-        place d’un système centralisé d’attribution des identifiants
-        </span>
+    -   <mark>Si le code technique est attribué par le
+        système local : code **LOC** (comme pour le profil SIRI). Note : un code
+        **LOC** est à considérer comme à priori temporaire, en attente de la mise en
+        place d’un système centralisé d’attribution des identifiants</mark>
 
-    -   <span class="hl">Pour le mode ferré, le code sera
-        </span>**<span class="hl">ERA</span>**<span class="hl">
-        (pour European Rail Agency) pour les identifiants issus de la
-        STI-TAP (à priori les codes UIC ne seront pas utilisés, mais si
-        c’était le cas, le code serait </span>**<span
-        class="hl">UIC</span>**<span class="hl">).</span>
+    -   <mark>Pour le mode ferré, le code sera **ERA** (pour European Rail Agency)
+        pour les identifiants issus de la STI-TAP (à priori les codes UIC ne
+        seront pas utilisés, mais si c’était le cas, le code serait **UIC**).</mark>
 
-<span class="hl">Examples : 
+<mark>Examples :</mark>
 
-* Gare ferrée "PARIS MONTPARNASSE 1 2" : `FR:75114:LMO:39100:ERA`
-* Arrêt de bus sur la commune de Guyancourt, attribué
-par un système transporteur : `FR:78297:ZE:110E8400-E29B-11D4-A716-446655440000:LOC`
-* Station de métro parisienne, avec identifiant STIF
-(REFLEX) : `FR:75105:LMO:43289:NUTS10`
-</span>
+* <mark>Gare ferrée "PARIS MONTPARNASSE 1 2" : `FR:75114:LMO:39100:ERA`</mark>
+* <mark>Arrêt de bus sur la commune de Guyancourt, attribué
+par un système transporteur : `FR:78297:ZE:110E8400-E29B-11D4-A716-446655440000:LOC`</mark>
+* <mark>Station de métro parisienne, avec identifiant STIF
+(REFLEX) : `FR:75105:LMO:43289:NUTS10`</mark>
 
-<span class="hl">Encore une fois, si l’arrêt a déjà été identifié dans
+<mark>Encore une fois, si l’arrêt a déjà été identifié dans
 le cadre d’un échange et que l’identifiant utilisé et unique au niveau
 national et pérenne, on conservera naturellement son identifiant et la
-codification ci-dessus ne s’applique plus.</span>
+codification ci-dessus ne s’applique plus.</mark>
 
 ## TypeOfFrame : types spécifiques 
 
@@ -4392,54 +4357,46 @@ d'indiquer ***version="any***"(par convention).
 Rappelons que la codification des identifiants est imposée par le
 profil.
 
-<span class="hl">De façon à systématiquement activer ce contrôle de
+<mark>De façon à systématiquement activer ce contrôle de
 cohérence, le profil rend obligatoire de toujours mettre une version
 associée aux identifiants, en offrant toutefois la convention
-d'utilisation du "</span>***<span class="hl">any</span>***<span
-class="hl">" si la version est indéfinie ou indifférente. De même, dans
+d'utilisation du "***any***" si la version est indéfinie ou indifférente. De même, dans
 un souci de qualité des données, il est obligatoire de faire figurer
-l'indication de version dans toutes les références (éventuellement
-positionné à "</span>***<span class="hl">any</span>***<span
-class="hl">") et ce pour tous les objets figurant dans le même document
-XML.</span>
+l'indication de version dans toutes les références (éventuellement positionné à
+"***any***") et ce pour tous les objets figurant dans le même document XML.</mark>
 
 Pour les objets externes (c’est-à-dire ne figurant pas dans le même
 document XML, ou étant définis dans un référentiel), il reste utile de
 préciser le numéro de ***version***. Si l'on précise un attribut de
 **version**, la vérification produit une erreur car, par définition, un
-objet externe ne sera pas présent dans le jeu de données. <span
-class="hl">Pour pallier cette difficulté, NeTEx permet de précise le
-numéro de version en utilisant l’attribut </span>**<span
-class="hl">versionRef</span>**<span class="hl"> (et non plus
-</span>**<span class="hl">version</span>**<span class="hl">) comme
-indiqué dans l'exemple ci-dessous:</span>
+objet externe ne sera pas présent dans le jeu de données.
+<mark>Pour pallier cette difficulté, NeTEx permet de précise le
+numéro de version en utilisant l’attribut **versionRef** (et non plus
+**version**) comme indiqué dans l'exemple ci-dessous:</mark>
 
 ```
-<TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_COMMUN" versionREf="1.01:FR-NETEX_COMMUN-1.0"/>
+<TypeOfFrameRef ref="FR:TypeOfFrame:NETEX_COMMUN" versionRef="1.01:FR-NETEX_COMMUN-1.0" />
 ```
-<span class="hl">Toutefois, contrairement aux références internes, la
-précision du numéro de </span>***<span
-class="hl">versionRef</span>***<span class="hl"> n'est pas obligatoire
+
+<mark>Toutefois, contrairement aux références internes, la
+précision du numéro de ***versionRef*** n'est pas obligatoire
 pour les références externes (on pourra cependant considérer comme une
 bonne pratique de systématiquement la fournir en indiquant
-"</span>***<span class="hl">any</span>***<span class="hl">" quand
-elle n'est pas connue ou pas utile).</span>
+"***any***" quand elle n'est pas connue ou pas utile).</mark>
 
-<span class="hl">De plus, pour simplifier l’utilisation de données et
+<mark>De plus, pour simplifier l’utilisation de données et
 ne pas imposer de systématiquement rechercher et charger l’objet
 référencé, le profil recommande, pour les objets externes uniquement, de
-faire figurer le nom (l’information portée par sa balise
-</span>**<span class="hl">name</span>**<span class="hl"> quand il y
-en a une) en tant que contenu de la balise référence.</span>
+faire figurer le nom (l’information portée par sa balise **name** quand il y
+en a une) en tant que contenu de la balise référence.</mark>
 
 ```
 <StopPlaceRef ref="FR:78297:LMO:110E8400:LOC" versionRef="8.3">Le Corbusier</StopPlaceRef>
 ```
 
-<span class="hl">Note : l’une des conclusions des point ci-dessus est
-que toute référence ne portant pas l’attribut </span>**<span
-class="hl">version</span>**<span class="hl"> correspond forcément à
-une référence vers un objet externe.</span>
+<mark>Note : l’une des conclusions des point ci-dessus est
+que toute référence ne portant pas l’attribut **version** correspond forcément à
+une référence vers un objet externe.</mark>
 
 <div class="table-title">VersionOfObjectRef (abstrait)</div>
 
@@ -4484,7 +4441,7 @@ une référence vers un objet externe.</span>
 <td><em>VersionIdType</em></td>
 <td>0:1</td>
 <td><p>Version de l’objet référencé dans le jeu de données courant.</p>
-<p><span class="hl">Doit systématiquement être instancié pour un objet présent dans le jeu de donnée (mettre « any » si la version n’est pas connue)</span>.</p></td>
+<p><mark>Doit systématiquement être instancié pour un objet présent dans le jeu de donnée (mettre « any » si la version n’est pas connue).</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -4492,7 +4449,7 @@ une référence vers un objet externe.</span>
 <td>VersionRef</td>
 <td>0:1</td>
 <td><p>Version de l’objet référencé dans un jeu de données externe.</p>
-<p><span class="hl">Mettre « any » si la version n’est pas connue</span>.</p></td>
+<p><mark>Mettre « any » si la version n’est pas connue.</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -4764,10 +4721,10 @@ profil.
 <tr class="odd">
 <td><em><strong>MessageIdentifier</strong></em></td>
 <td><p>0:1</p>
-<p><strong><span class="hl">1 :1</span></strong></p></td>
+<p><strong><mark>1:1</mark></strong></p></td>
 <td><em>Message­Qualifier</em></td>
 <td><p>Identifiant unique de la requête de souscription (utilisé dans la réponse).</p>
-<p><span class="hl">Comme pour le profil SIRI, ce champ est obligatoire dans le cadre du profil NeTEx </span></p></td>
+<p><mark>Comme pour le profil SIRI, ce champ est obligatoire dans le cadre du profil NeTEx.</mark></p></td>
 </tr>
 <tr class="even">
 <td><em>Payl­oad</em></td>
@@ -4842,7 +4799,7 @@ n'est pas pris en charge).
 <td></td>
 <td><em>srsNameType</em></td>
 <td><p>Nom du référentiel (GML) de localisation utilisé</p>
-<p><span class="hl">Les deux formats (WGS 84 systèmatique et générique GML) sont autorisés. (</span><em><u><span class="hl">note</span></u></em><span class="hl"> : il existe de nombreux outils libres permettant de convertir les coordonnées d’un référentiel à l’autre).</span></p></td>
+<p><mark>Les deux formats (WGS 84 systèmatique et générique GML) sont autorisés. (<em><u>note</u></em> : il existe de nombreux outils libres permettant de convertir les coordonnées d’un référentiel à l’autre).</mark></p></td>
 </tr>
 <tr class="even">
 <td rowspan="2"><em>Temporal Span</em></td>
@@ -4863,19 +4820,19 @@ n'est pas pris en charge).
 <td>0:1</td>
 <td><em>fetch | direct</em></td>
 <td><p>Delivery pattern</p>
-<p><span class="hl">Abonnement à une phase (voir en début de document) uniquement : donc </span><em><span class="hl">direct</span>.</em></p></td>
+<p><mark>Abonnement à une phase (voir en début de document) uniquement : donc <em>direct</em>.</mark></p></td>
 </tr>
 <tr class="odd">
 <td colspan="2"><em><strong>MultipartDespatch</strong></em></td>
 <td>0:1</td>
 <td><em>xsd:boolean</em></td>
-<td><span class="hl">Autorisation de segmentation des messages : </span><strong><span class="hl">Non</span></strong><span class="hl"> dans le profil</span>.</td>
+<td><mark>Autorisation de segmentation des messages : <strong>Non</strong> dans le profil</mark>.</td>
 </tr>
 <tr class="even">
 <td colspan="2"><em><strong>ConfirmReceipt</strong></em></td>
 <td>0:1</td>
 <td><em>xsd:boolean</em></td>
-<td><span class="hl">Confirmation des réceptions: </span><strong><span class="hl">Non</span></strong> <span class="hl">dans le profil</span>.</td>
+<td><mark>Confirmation des réceptions : <strong>Non</strong> dans le profil.</mark></td>
 </tr>
 </tbody>
 </table>
@@ -4945,7 +4902,7 @@ réponse).
 <td><em>TypeOfFrame­RefStructure</em></td>
 <td>0:1</td>
 <td><p>Permet de ne consulter que les données d’un type de cadre de version spécifique.</p>
-<p><span class="hl">S’il est utilisé, ce champ ne peut valoir que </span><strong><span class="hl">NETEX_COMMUN, NETEX_ARRET, NETEX_RESEAU, NETEX_HORAIRE, NETEX_CALENDRIER, NETEX_TARIF, NETEX_FRANCE </span></strong><em><span class="hl">(correspondant à tous les types de CADRE définis par les profils)</span></em></p></td>
+<p><mark>S’il est utilisé, ce champ ne peut valoir que <strong>NETEX_COMMUN, NETEX_ARRET, NETEX_RESEAU, NETEX_HORAIRE, NETEX_CALENDRIER, NETEX_TARIF, NETEX_FRANCE</strong> <em>(correspondant à tous les types de CADRE définis par les profils)</em>.</mark></p></td>
 </tr>
 <tr class="even">
 <td rowspan="2"><em>Topic Frame Scope</em></td>
@@ -4970,7 +4927,7 @@ réponse).
 |---------------------------|-------------------------|------------------------|------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Object By Value           | ***BoundingBox***       | *BoundingBoxStructure* | 0:\* | Ce filtre permet de ne demander que les données à l’intérieur d’un périmètre géographique spécifié.                                                     |
 |                           | ***object­References*** | *VersionOfObjectRef*   | 0:\* | Permet de spécifier l’identifiant de l’objet recherché. Si l’identifiant n’est pas précisé, tous les objets de la classe correspondante sont retournés. |
-| *Network Filter By Value* | ***NetworkRef***        | *NetworkRefStructure*  | 0:1  | Permets de n’obtenir que les objets d’un réseau (NETWORK) <span class="hl">ou d’un groupe de lignes (GROUP OF LINES)</span> spécifique.                |
+| *Network Filter By Value* | ***NetworkRef***        | *NetworkRefStructure*  | 0:1  | Permets de n’obtenir que les objets d’un réseau (NETWORK) <mark>ou d’un groupe de lignes (GROUP OF LINES)</mark> spécifique.                |
 
 <div class="table-title">FrameRequestPolicy – Element</div>
 
@@ -5025,16 +4982,16 @@ la requête, seul le ***ServiceDelivery*** de la réponse sera utilisé.
 <td></td>
 <td colspan="2"><em><strong>RequestMessageRef</strong></em></td>
 <td><p>0:1</p>
-<p><strong><span class="hl">1:1</span></strong></p></td>
+<p><strong><mark>1:1</mark></strong></p></td>
 <td><em>->Message­Qualifier</em></td>
 <td><p>Référence de la requête.</p>
-<p><span class="hl">Obligatoire, en cohérence avec le profil SIRI</span></p></td>
+<p><mark>Obligatoire, en cohérence avec le profil SIRI</mark></p></td>
 </tr>
 <tr class="even">
 <td rowspan="2"><em>Stat­us</em></td>
 <td colspan="2"><em><strong>Status</strong></em></td>
 <td><p>0:1</p>
-<p><strong><span class="hl">1:1</span></strong></p></td>
+<p><strong><mark>1:1</mark></strong></p></td>
 <td><em>xsd:boolean</em></td>
 <td>Indique si la requête a pu être traitée avec succès ou non.</td>
 </tr>
@@ -5043,7 +5000,7 @@ la requête, seul le ***ServiceDelivery*** de la réponse sera utilisé.
 <td>0:1</td>
 <td><em>See below</em></td>
 <td><p>Signalement d’erreur (voir le paragraphe sur la gestion des erreurs).</p>
-<p><span class="hl">Voir le profil SIRI pour le détail de la gestion des erreurs. Le détail des erreurs est porté par le DataObjectDelivery décrit plus bas (voir profil SIRI chapitre </span><em><strong><span class="hl">Gestion des Erreurs</span></strong></em><span class="hl">)</span>.</p></td>
+<p><mark>Voir le profil SIRI pour le détail de la gestion des erreurs. Le détail des erreurs est porté par le DataObjectDelivery décrit plus bas (voir profil SIRI chapitre <em><strong>Gestion des Erreurs</strong></em>).</mark></p></td>
 </tr>
 <tr class="odd">
 <td><em>Payload</em></td>
@@ -5094,7 +5051,7 @@ la requête, seul le ***ServiceDelivery*** de la réponse sera utilisé.
 <td><em>Choice</em></td>
 <td colspan="2"><em><strong>RequestMessageRef</strong></em></td>
 <td><p>0:1</p>
-<p><strong><span class="hl">1:1</span></strong></p></td>
+<p><strong><mark>1:1</mark></strong></p></td>
 <td><em>Message­Qualifier</em></td>
 <td>Référence de la requête.</td>
 </tr>
@@ -5102,7 +5059,7 @@ la requête, seul le ***ServiceDelivery*** de la réponse sera utilisé.
 <td><em>Pay­load</em></td>
 <td colspan="2"><em><strong>Status</strong></em></td>
 <td><p>0:1</p>
-<p><strong><span class="hl">1:1</span></strong></p></td>
+<p><strong><mark>1:1</mark></strong></p></td>
 <td><em>xsd:boolean</em></td>
 <td>Indique si la requête a été traitée normalement ou pas.</td>
 </tr>
@@ -5111,7 +5068,7 @@ la requête, seul le ***ServiceDelivery*** de la réponse sera utilisé.
 <td colspan="2"><em><strong>Error</strong></em>­<em><strong>Condition</strong></em></td>
 <td>0:1</td>
 <td><em>+Structure</em></td>
-<td>Signalement d’erreur <span class="hl">(voir profil SIRI, chapitre </span><em><strong><span class="hl">Gestion des Erreurs</span></strong></em>).</td>
+<td>Signalement d’erreur (<mark>voir profil SIRI, chapitre <em><strong>Gestion des Erreurs</strong></em></mark>).</td>
 </tr>
 <tr class="odd">
 <td><em>Info</em></td>

--- a/NeTEx/horaires/index.md
+++ b/NeTEx/horaires/index.md
@@ -605,7 +605,7 @@ proposent ces colonnes:
     les textes surlignés en jaune indiquent une spécificité du profil
     par rapport à NeTEx).
 
-Les textes surlignés en <span class="hl">Jaune</span> sont ceux
+Les textes surlignés en <mark>Jaune</mark> sont ceux
 présentant une particularité (spécialisation) par rapport à NeTEx: une
 codification particulière, une restriction d'usage, etc.
 
@@ -720,7 +720,7 @@ autorisés à monter à bord ou à descendre du véhicule aux arrêts.
 <td><em>ServiceAlterationEnumeration</em></td>
 <td>0:1</td>
 <td><p>Indique si la course est planifiée (valeur par défaut), si elle est annulée ou si c’est une course additionnelle.</p>
-<p><span class="hl">Ce champ n’est à utiliser que pour les mises à jour tardives dans les cas où cette information n’est pas diffusée avec SIRI (service Producion Timetable)</span></p></td>
+<p><mark>Ce champ n’est à utiliser que pour les mises à jour tardives dans les cas où cette information n’est pas diffusée avec SIRI (service Producion Timetable).</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -741,7 +741,7 @@ autorisés à monter à bord ou à descendre du véhicule aux arrêts.
 <td colspan="2"><em><strong><del>Frequency</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">L'information de fréquence est fournie par la COURSE MODÈLE (voir </span><em><strong><span class="hl">frequencyGroups</span></strong></em><span class="hl"> de </span><em><strong><span class="hl">TemplateVehicleJourney</span></strong></em><span class="hl">)</span></td>
+<td><mark>L'information de fréquence est fournie par la COURSE MODÈLE (voir <em><strong>frequencyGroups</strong></em> de <em><strong>TemplateVehicleJourney</strong></em>).</mark></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -762,7 +762,7 @@ autorisés à monter à bord ou à descendre du véhicule aux arrêts.
 <td colspan="2"><em><strong><del>RouteRef</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Voir le PARCOURS</span></td>
+<td><mark>Voir le PARCOURS.</mark></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -785,7 +785,7 @@ autorisés à monter à bord ou à descendre du véhicule aux arrêts.
 <td>OperatorRef</td>
 <td>0:1</td>
 <td><p>Référence l'EXPLOITANT opérant cette course.</p>
-<p><span class="hl">Il n'est indiqué que s’il est différent de celui de la ligne.</span></p></td>
+<p><mark>Il n'est indiqué que s’il est différent de celui de la ligne.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«EV»</td>
@@ -793,7 +793,7 @@ autorisés à monter à bord ou à descendre du véhicule aux arrêts.
 <td><em><strong>LineRef</strong></em></td>
 <td>LineRef</td>
 <td>0:1</td>
-<td>Référence la LIGNE à laquelle appartient la COURSE <span class="hl">(pour simplifier la navigation COURSE->PARCOURS->ITINERAIRE->LIGNE). Il peut naturellement s'agir d'une LIGNE FLEXIBLE.</span></td>
+<td>Référence la LIGNE à laquelle appartient la COURSE <mark>(pour simplifier la navigation COURSE->PARCOURS->ITINERAIRE->LIGNE). Il peut naturellement s'agir d'une LIGNE FLEXIBLE.</mark></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -809,21 +809,21 @@ autorisés à monter à bord ou à descendre du véhicule aux arrêts.
 <td><em>trainNumberRefs</em></td>
 <td>0:*</td>
 <td><p>Référence le numéro de train associé.</p>
-<p><span class="hl">Note: le NUMERO DE TRAIN est un objet indépendant, qui est ici référencé.</span></p></td>
+<p><mark>Note : le NUMERO DE TRAIN est un objet indépendant, qui est ici référencé.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
 <td colspan="2">Origin</td>
 <td></td>
 <td></td>
-<td><span class="hl">Voir le PARCOURS.</span></td>
+<td><mark>Voir le PARCOURS.</mark></td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>
 <td colspan="2">Destination</td>
 <td></td>
 <td></td>
-<td><span class="hl">Voir le PARCOURS.</span></td>
+<td><mark>Voir le PARCOURS.</mark></td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>
@@ -845,8 +845,8 @@ autorisés à monter à bord ou à descendre du véhicule aux arrêts.
 <td><em>journeyParts</em></td>
 <td>0:*</td>
 <td><p>Références à des parties de COURSE (JOURNEY PART) constituant la COURSE.</p>
-<p><span class="hl">Utilisé pour un certain nombre de situations du mode ferré (changement de parité ou de numéro de train) ainsi que pour des situations comme le changement d'exploitant en cours de course sur les RER A et B.</span></p>
-<p><span class="hl">Contrairement à la règle générale dans les profils NeTEx, et afin de pouvoir être réutilisées, les JOURNEY PARTs seront systématiquement définies indépendamment (à la racine de l'élément </span><em><strong><span class="hl">members</span></strong></em><span class="hl"> du FRAME) et simplement référencées ici (et non incluse, même si le modèle l'autorise).</span></p></td>
+<p><mark>Utilisé pour un certain nombre de situations du mode ferré (changement de parité ou de numéro de train) ainsi que pour des situations comme le changement d'exploitant en cours de course sur les RER A et B.</mark></p>
+<p><mark>Contrairement à la règle générale dans les profils NeTEx, et afin de pouvoir être réutilisées, les JOURNEY PARTs seront systématiquement définies indépendamment (à la racine de l'élément <em><strong>members</strong></em> du FRAME) et simplement référencées ici (et non incluse, même si le modèle l'autorise).</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -854,7 +854,7 @@ autorisés à monter à bord ou à descendre du véhicule aux arrêts.
 <td><em>calls_RelStructure</em></td>
 <td>0:*</td>
 <td><p>La notion de Call est une vue agrégée de différentes propriétés lors d'un évènement (souvent le passage à un arrêt)</p>
-<p><span class="hl">Cette notion est héritée de SIRI et ne correspond pas à la modélisation des passages aux arrêts. La notion de Call n'est donc pas retenue dans le profil France.</span></p>
+<p><mark>Cette notion est héritée de SIRI et ne correspond pas à la modélisation des passages aux arrêts. La notion de Call n'est donc pas retenue dans le profil France.</mark></p>
 </td>
 </tr>
 <tr class="odd">
@@ -869,7 +869,7 @@ autorisés à monter à bord ou à descendre du véhicule aux arrêts.
 <td colspan="2"><em><strong>TrainSize</strong></em></td>
 <td>TrainSizeStructure</td>
 <td>0:1</td>
-<td>Information sur la taille du train (long/court). <span class="hl">Peut aussi servir pour identifier les bus articulés ou couplés.</span></td>
+<td>Information sur la taille du train (long/court). <mark>Peut aussi servir pour identifier les bus articulés ou couplés.</mark></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -908,7 +908,7 @@ Pour ***TrainSize*** voir *6.10.1-Train.*
 <td colspan="2"><em>::></em></td>
 <td><em>LinkSequence</em></td>
 <td><em>::></em></td>
-<td>JOURNEY hérite de LINK SEQUENCE <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>JOURNEY hérite de LINK SEQUENCE <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -923,7 +923,7 @@ Pour ***TrainSize*** voir *6.10.1-Train.*
 <td><em>VehicleModeEnum</em></td>
 <td>0:1</td>
 <td><p>Transport MODE de JOURNEY.</p>
-<p><span class="hl">Le mode n'est précisé que s'il est différent de celui de la ligne (exemple: bus de substitution SNCF)</span>.</p></td>
+<p><mark>Le mode n'est précisé que s'il est différent de celui de la ligne (exemple: bus de substitution SNCF).</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -931,21 +931,21 @@ Pour ***TrainSize*** voir *6.10.1-Train.*
 <td><em>TransportSubmode</em></td>
 <td>0:1</td>
 <td><p>SOUS MODE de transport de JOURNEY.</p>
-<p><span class="hl">Le sous-mode n'est précisé que s'il est différent de celui de la ligne.</span></p></td>
+<p><mark>Le sous-mode n'est précisé que s'il est différent de celui de la ligne.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
 <td colspan="2"><em><strong><del>Monitored</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Fourni au niveau LIGNE.</span></td>
+<td><mark>Fourni au niveau LIGNE.</mark></td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>
 <td colspan="2"><em><strong><del>journeyAccountings</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Le profil étant dédié à l'information voyageur, les notions de comptabilité ne sont pas prises en compte, mais pourraient être nécessaires dans d'autres contextes.</span></td>
+<td><mark>Le profil étant dédié à l'information voyageur, les notions de comptabilité ne sont pas prises en compte, mais pourraient être nécessaires dans d'autres contextes.</mark></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -966,17 +966,17 @@ Pour ***TrainSize*** voir *6.10.1-Train.*
 
 | **Classifi­cation**  | **Name**                  | **Type**               | **Cardin­ality**  | **Description**       |
 |---------------------|---------------------------|------------------------|------------------| ----------------------|
-| *::>*               | *::>*                     | *VersionedChild*       | *::>*            | PASSING TIME hérite de VERSIONED CHILD <span class="hl">(non utilisé dans le profil)</span>                                                                                                                                                                                                                     |
+| *::>*               | *::>*                     | *VersionedChild*       | *::>*            | PASSING TIME hérite de VERSIONED CHILD <mark>(non utilisé dans le profil)</mark>                                                                                                                                                                                                                     |
 | «FK»                | PointInJourney­PatternRef  | PointInLinkSequenceRef | 0:1              | Référence les POINT D'ARRÊT PLANIFIÉ pour lequel on fournit les heures de passage. Ce point peut aussi, de façon plus exceptionnel être un POINT HORAIRE uniquement.                                                                                                                                            |
 |                     | ArrivalTime               | xsd:time               | 0:1              | Heure d'arrivée.                                                                                                                                                                                                                                                                                                |
 |                     | ***ArrivalDayOffset***    | *xsd:integer*          | 0:1              | Nombre de jours de décalage par rapport au jour de début de course (permet de gérer les courses à cheval sur plusieurs jours).                                                                                                                                                                                   |
 |                     | DepartureTime             | xsd:time               | 0:1              | Heure de départ.                                                                                                                                                                                                                                                                                                |
 |                     | ***DepartureDayOffset***  | *xsd:integer*          | 0:1              | Nombre de jours de décalage par rapport au jour de début de course (permet de gérer les courses à cheval sur plusieurs jours).                                                                                                                                                                                   |
 |                     | Headway                   | HeadwayInterval        | 0:1              | Temps d'attente moyen avant le prochain passage d'une COURSE empruntant le même PARCOURS.                                                                                                                                                                                                                       |
-|                     | EarliestDeparture­Time     | xsd:time               | 0:1              | Heure de départ au plus tôt <span class="hl">(il s'agit là de l'engagement de service du transporteur ou de l'AOT; il permettra notamment de sécuriser les correspondances; il permet aussi d'indiquer la précision de l'heure de passage, en particuliers aux points ou l'horaire est interpolé).</span>     |
-|                     | LatestArrivalTime         | xsd:time               | 0:1              | Heure de d'arrivée au plus tard <span class="hl">(il s'agit là de l'engagement de service du transporteur ou de l'AOT; il permettra notamment de sécuriser les correspondances; il permet aussi d'indiquer la précision de l'heure de passage, en particuliers aux points ou l'horaire est interpolé).</span> |
+|                     | EarliestDeparture­Time     | xsd:time               | 0:1              | Heure de départ au plus tôt <mark>(il s'agit là de l'engagement de service du transporteur ou de l'AOT ; il permettra notamment de sécuriser les correspondances ; il permet aussi d'indiquer la précision de l'heure de passage, en particuliers aux points ou l'horaire est interpolé).</mark>     |
+|                     | LatestArrivalTime         | xsd:time               | 0:1              | Heure de d'arrivée au plus tard <mark>(il s'agit là de l'engagement de service du transporteur ou de l'AOT ; il permettra notamment de sécuriser les correspondances ; il permet aussi d'indiquer la précision de l'heure de passage, en particuliers aux points ou l'horaire est interpolé).</mark> |
 
-*<span class="hl">Note: pour les courses en fréquence, les nécessaires
+<mark>*Note : pour les courses en fréquence, les nécessaires
 temps de parcours (pour le calcul d'itinéraire) seront calculés à partir
 des heures de passage de la COURSE MODÈLE (la fourniture explicite des
 temps de parcours, ou RUN TIME, nécessite la définition des TIMING
@@ -984,7 +984,7 @@ LINKs, alourdissant sensiblement l'échange sans pour autant
 véritablement apporter une information supplémentaire dans un contexte
 d'information voyageur). Le calcul du temps de parcours sera réalisé par
 simple différence des heures de départs (DepartureTime) aux différents
-arrêts.</span>*
+arrêts.*</mark>
 
 ### Propriétés de course flexible
 
@@ -1011,8 +1011,8 @@ arrêts.</span>*
 <td><em>::></em></td>
 <td><em>DataManagedObject</em></td>
 <td><em>::></em></td>
-<td><p>FLEXIBLE SERVICE PROPERTIES hérite de DATA MANAGED OBJECT <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</p>
-<p><span class="hl">Non utilisé ici</span>.</p></td>
+<td><p>FLEXIBLE SERVICE PROPERTIES hérite de DATA MANAGED OBJECT <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</p>
+<p><mark>Non utilisé ici.</mark></p></td>
 </tr>
 
 <tr class="even">
@@ -1020,7 +1020,7 @@ arrêts.</span>*
 <td><em><strong>Booking­Arrangements</strong></em></td>
 <td><em>BookingArrangements</em></td>
 <td>0:1</td>
-<td>Informations de contact pour les services flexibles <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx réseau</span></strong></em><span class="hl">)</span>.</td>
+<td>Informations de contact pour les services flexibles <mark>(<em>voir le document <strong>Profil NeTEx réseau</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1033,7 +1033,7 @@ arrêts.</span>*
 <li><p><em>fixedHeadwayFrequency</em>: fréquence de passage fixe (par exemple toute les 30 minutes) mais maintenue uniquement s'il y a une demande (réservation)</p></li>
 <li><p><em>fixedPassingTimes</em>: heures de passage aux arrêts fixes (planifiées) mais maintenue uniquement s'il y a une demande (réservation)</p></li>
 <li><p><em>notFlexible</em>: service régulier</p></li>
-<li><p><em>other</em>: autre type de flexibilité <span class="hl">(associer une NOTE à la course)</span></p></li>
+<li><p><em>other</em> : autre type de flexibilité <mark>(associer une NOTE à la course)</mark></p></li>
 </ul></td>
 </tr>
 <tr class="even">
@@ -1146,7 +1146,7 @@ Les PARTIEs DE COURSE seront généralement spécifiques au mode ferré.
 
 | **Classification** | **Name** | **Type** | **cardinality** | **Description** |
 |-|-|-|-|-|
-| *::>* | *::>* | *DataManagedObject* | *::>* | JOURNEY PART hérite de DATA MANAGED OBJECT <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span>. |
+| *::>* | *::>* | *DataManagedObject* | *::>* | JOURNEY PART hérite de DATA MANAGED OBJECT <mark>(*voir le document **Profil NeTEx éléments communs***)</mark>. |
 | | ***Description*** | *MultilingualString* | 0:1 | Description de la PARTIE DE COURSE. |
 | «FK» | ***ParentJourneyRef*** | *VehicleJourneyRef* | 0:1 | COURSE à laquelle appartient cette PARTIE DE COURSE. |
 | «FK» | ***MainPartRef*** | *JourneyPartCoupleRef* | 1:1 | Référence à la PARTIE DE COURSE principale (l'une des différentes PARTIE DE COURSE doit être déclarée comme principale). |
@@ -1200,7 +1200,7 @@ route car les composants du train sont couplés et découplés.
 <td><em>::></em></td>
 <td><em>DataManagedObject</em></td>
 <td><em>::></em></td>
-<td><p>TRAIN NUMBER hérite de DATA MANAGED OBJECT <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</p>
+<td><p>TRAIN NUMBER hérite de DATA MANAGED OBJECT <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</p>
 <p>Le champ <em><strong>Id</strong></em> est naturellement l'identifiant du NUMÉRO DE TRAIN (c'est le numéro de train lui-même).</p></td>
 </tr>
 <tr class="odd">
@@ -1208,14 +1208,14 @@ route car les composants du train sont couplés et découplés.
 <td><em><strong>Description</strong></em></td>
 <td><em>MultilingualString</em></td>
 <td>0:1</td>
-<td>Texte descriptif associé au NUMÉRO DE TRAIN <span class="hl">et à utiliser pour l'information voyageur (devra figurer en complément du numéro de train).</span></td>
+<td>Texte descriptif associé au NUMÉRO DE TRAIN <mark>et à utiliser pour l'information voyageur (devra figurer en complément du numéro de train)</mark>.</td>
 </tr>
 <tr class="even">
 <td></td>
 <td><em><strong>ForAdvertisement</strong></em></td>
 <td><em>xsd:normalizedString</em></td>
 <td>0:1</td>
-<td>NUMÉRO DE TRAIN utilisé pour la communication au public <span class="hl">(parfois différent du numéro technique: si ce champ est présent il sera systématiquement utilisé pour l'information voyageur).</span></td>
+<td>NUMÉRO DE TRAIN utilisé pour la communication au public <mark>(parfois différent du numéro technique : si ce champ est présent il sera systématiquement utilisé pour l'information voyageur)</mark>.</td>
 </tr>
 
 </tbody>
@@ -1233,21 +1233,21 @@ les courses passant dans un créneau d'une heure).
 ![image](media/image4.svg)
 *Template Service Journey – Modèle conceptuel*
 
-<span class="hl">Pour les courses en fréquence le calcul du temps de
+<mark>Pour les courses en fréquence le calcul du temps de
 parcours sera réalisé par simple différence des heures de départs
 (DepartureTime) aux différents arrêts de la course modèle. Par
 convention, la course modèle pour les services en fréquence sera, en
 termes d'horaire de passage, la première course de la tranche horaire
 décrite (avec généralement un calage au premier arrêt sur l'heure de
-début de la tranche horaire).</span>
+début de la tranche horaire).</mark>
 
-<span class="hl">Pour les courses en cadence on prendra comme
+<mark>Pour les courses en cadence on prendra comme
 convention de n'indiquer que les minutes des horaires de passage
 (l'heure sera donc fixe, à 0, un arrêt desservi toutes les heures dix,
 vingt-cinq et cinquante, aura donc des horaire 0:10, 0:25 et 0:50). Il
 ne s'agit là que d'une convention, dans tous les cas, la partie heure de
 l'horaire de passage peut être ignorée dans le cadre des
-cadences.</span>
+cadences.</mark>
 
 <div class="table-title">TemplateVehicleJourney – Element</div>
 
@@ -1293,7 +1293,7 @@ cadences.</span>
 <td><em>JourneyFrequencyGroup</em></td>
 <td>0:*</td>
 <td><p>Référence à la description du service en fréquence ou en cadence que la COURSE MODÈLE décrit.</p>
-<p><span class="hl">Seules les références </span><em><strong><span class="hl">xxxxRef</span></strong></em><span class="hl"> (</span><em><strong><span class="hl">HeadwayJourneyGroupRef</span></strong></em><span class="hl"> pour les services en fréquence ou </span><em><strong><span class="hl">RhythmicalJourneyGroupRef</span></strong></em><span class="hl"> pour les services en cadence) seront utilisées dans le cadre du profil.</span></p></td>
+<p><mark>Seules les références <em><strong>xxxxRef</strong></em> (<em><strong>HeadwayJourneyGroupRef</strong></em> pour les services en fréquence ou <em><strong>RhythmicalJourneyGroupRef</strong></em> pour les services en cadence) seront utilisées dans le cadre du profil.</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -1332,7 +1332,7 @@ cadences.</span>
 <td><em>::></em></td>
 <td><em>GroupOfEntities</em></td>
 <td><em>::></em></td>
-<td>JOURNEY FREQUENCY GROUP hérite de GROUP OF ENTITies <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>JOURNEY FREQUENCY GROUP hérite de GROUP OF ENTITies <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1341,7 +1341,7 @@ cadences.</span>
 <td>1:1</td>
 <td><p>Heure du premier départ dans le GROUPE DE FRÉQUENCE.</p>
 <p>Il s'agit là de l'heure de passage du premier départ au premier arrêt de la course.</p>
-<p><span class="hl">S'il n'y a pas de régulation des heures de premier départ dans les tranches horaires, on indiquera uniquement l'heure de début de tranche horaire (pour un bus toute les 10 minutes de 8h00 à 9h30 on indiquera donc 8h00 même s'il n'y a pas de garantie d'un départ à 8h00).</span></p></td>
+<p><mark>S'il n'y a pas de régulation des heures de premier départ dans les tranches horaires, on indiquera uniquement l'heure de début de tranche horaire (pour un bus toute les 10 minutes de 8h00 à 9h30 on indiquera donc 8h00 même s'il n'y a pas de garantie d'un départ à 8h00).</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1350,7 +1350,7 @@ cadences.</span>
 <td>0:1</td>
 <td><p>Heure du dernier départ dans le GROUPE DE FRÉQUENCE.</p>
 <p>Il s'agit là de l'heure de passage du dernier départ au premier arrêt de la course.</p>
-<p><span class="hl">S'il n'y a pas de régulation des heures de dernier départ dans les tranches horaires, on indiquera uniquement l'heure de fin de tranche horaire (pour un bus toute les 10 minutes de 8h00 à 9h30 on indiquera donc 9h30 même s'il n'y a pas de garantie d'un départ à 9h30).</span></p></td>
+<p><mark>S'il n'y a pas de régulation des heures de dernier départ dans les tranches horaires, on indiquera uniquement l'heure de fin de tranche horaire (pour un bus toute les 10 minutes de 8h00 à 9h30 on indiquera donc 9h30 même s'il n'y a pas de garantie d'un départ à 9h30).</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1378,7 +1378,7 @@ cadences.</span>
 | **Classifi­cation** | **Name**  | **Type**                | **Cardin­ality** | **Description**                                                                                                 |
 |---------------------|-----------|-------------------------|------------------|-----------------------------------------------------------------------------------------------------------------|
 | *::>*               | *::>*     | *JourneyFrequencyGroup* | *::>*            | RHYTHMICAL JOURNEY GROUP hérite de JOURNEY FREQUENCY GROUP.                                                     |
-| «cntd»              | timebands |                         |                  | <span class="hl">On utilisera uniquement les COURSEs MODÈLEs pour décrire les services en cadencement.</span> |
+| «cntd»              | timebands |                         |                  | <mark>On utilisera uniquement les COURSEs MODÈLEs pour décrire les services en cadencement.</mark> |
 
 ## Les Courses couplées
 
@@ -1389,8 +1389,8 @@ cadences.</span>
 
 | **Classifi­cation** | **Name**          | **Type**             | **Cardin­ality** | **Description**                                                                                                                                                                                               |
 |---------------------|-------------------|----------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| *::>*               | *::>*             | *DataManagedObject*  | *::>*            | COUPLED JOURNEY hérite de DATA MANAGED OBJECT <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span>. |
-|                     | ***Description*** | *MultilingualString* | 0:1              | Description de la COURSE COUPLÉE <span class="hl">(texte utilisable pour l'information voyageur)</span>.                                                                                                    |
+| *::>*               | *::>*             | *DataManagedObject*  | *::>*            | COUPLED JOURNEY hérite de DATA MANAGED OBJECT <mark>(*voir le document **Profil NeTEx éléments communs***)</mark>. |
+|                     | ***Description*** | *MultilingualString* | 0:1              | Description de la COURSE COUPLÉE <mark>(texte utilisable pour l'information voyageur)</mark>.                                                                                                    |
 | «cntd»              | ***journeys***    | *VehicleJourney*     | 0:\*             | Référence vers les COURSEs qui sont associées ensemble.                                                                                                                                                       |
 
 ### Parties de courses couplées
@@ -1418,7 +1418,7 @@ cadences.</span>
 <td><em>::></em></td>
 <td><em>DataManagedObject</em></td>
 <td><em>::></em></td>
-<td>JOURNEY PART COUPLE hérite de DATA MANAGED OBJECT <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>JOURNEY PART COUPLE hérite de DATA MANAGED OBJECT <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1432,7 +1432,7 @@ cadences.</span>
 <td><em><strong>StartTime</strong></em></td>
 <td><em>xsd:time</em></td>
 <td>1:1</td>
-<td>Heure de début du couplage <span class="hl">(heure de départ au point de départ)</span></td>
+<td>Heure de début du couplage <mark>(heure de départ au point de départ)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1447,7 +1447,7 @@ cadences.</span>
 <td><em>xsd:time</em></td>
 <td>1:1</td>
 <td><p>Heure de fin du couplage.</p>
-<p><span class="hl">Il s'agit de l'heure d'arrivée au point de d'arrivé, ou à défaut de l'heure de premier départ du point d'arrivée (première des courses couplées à quitter le point d'arrivée).</span></p></td>
+<p><mark>Il s'agit de l'heure d'arrivée au point de d'arrivé, ou à défaut de l'heure de premier départ du point d'arrivée (première des courses couplées à quitter le point d'arrivée).</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1502,9 +1502,9 @@ cadences.</span>
 |---------------------|---------------------------|-------------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | *::>*               | *::>*                     | *Interchange*           | *::>*            | SERVICE JOURNEY INTERCHANGE hérite de INTERCHANGE.                                                                                                      |
 | «FK»                | ***FromPointRef***        | *ScheduledStopPointRef* | 1:1              | POINT D'ARRÊT planifié au départ de la correspondance.                                                                                                  |
-|                     | ***~~FromVisitNumber~~*** |                         |                  | <span class="hl">On utilisera les horaires de passage et de correspondance pour distinguer deux passages au même point d'arrêt, si nécessaire.</span> |
+|                     | ***~~FromVisitNumber~~*** |                         |                  | <mark>On utilisera les horaires de passage et de correspondance pour distinguer deux passages au même point d'arrêt, si nécessaire.</mark> |
 | «FK»                | ***ToPointRef***          | *ScheduledStopPointRef* | 1:1              | POINT D'ARRÊT planifié auquel donne accès la correspondance.                                                                                            |
-|                     | ***~~ToVisitNumber~~***   |                         |                  | <span class="hl">On utilisera les horaires de passage et de correspondance pour distinguer deux passages au même point d'arrêt, si nécessaire.</span> |
+|                     | ***~~ToVisitNumber~~***   |                         |                  | <mark>On utilisera les horaires de passage et de correspondance pour distinguer deux passages au même point d'arrêt, si nécessaire.</mark> |
 | «FK»                | ***FromJourneyRef***      | *ServiceJourneyRef*     | 1:1              | COURSE de départ.                                                                                                                                       |
 | «FK»                | ***ToJourneyRef***        | *ServiceJourneyRef*     | 1:1              | COURSE à laquelle donne accès la correspondance.                                                                                                        |
 
@@ -1531,7 +1531,7 @@ cadences.</span>
 <td><em>::></em></td>
 <td><em>DataManagedObject</em></td>
 <td><em>::></em></td>
-<td>INTERCHANGE hérite de DATA MANAGED OBJECT <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>INTERCHANGE hérite de DATA MANAGED OBJECT <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 
 
@@ -1542,7 +1542,7 @@ cadences.</span>
 <td><em><strong>ConnectionRef</strong></em></td>
 <td><em>ConnectionRef</em></td>
 <td>0:1</td>
-<td>Lien avec la CORRESPONDANCE physique sur laquelle s'opère la CORRESPONDANCE ENTRE COURSEs <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx Réseau</span></strong></em><span class="hl">)</span>.</td>
+<td>Lien avec la CORRESPONDANCE physique sur laquelle s'opère la CORRESPONDANCE ENTRE COURSEs <mark>(<em>voir le document <strong>Profil NeTEx Réseau</strong></em>)</mark>.</td>
 </tr>
 
 <tr class="odd">
@@ -1551,7 +1551,7 @@ cadences.</span>
 <td><em>xsd:boolean</em></td>
 <td>0:1</td>
 <td><p>Permet d'indiquer que la course en correspondance est assurée par le même véhicule que la course amenante et que le passager peut simplement rester dans le véhicule et n'a donc pas besoin de descendre.</p>
-<p><span class="hl">Cela sera utile pour les lignes en boucle par exemple, ou encore si l'on décide de modéliser un changement d'exploitant par des courses distinctes (cas des RER A et B en région parisienne par exemple).</span></p></td>
+<p><mark>Cela sera utile pour les lignes en boucle par exemple, ou encore si l'on décide de modéliser un changement d'exploitant par des courses distinctes (cas des RER A et B en région parisienne par exemple).</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1577,7 +1577,7 @@ cadences.</span>
 <td><em><strong>notice­Assignments</strong></em></td>
 <td><em>NoticeAssignmentView</em></td>
 <td>0:*</td>
-<td>NOTE associé à la correspondance <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>NOTE associé à la correspondance <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 </tbody>
 </table>
@@ -1608,10 +1608,10 @@ cadences.</span>
 <td><em><strong>StandardTransferTime</strong></em></td>
 <td><em>xsd:duration</em></td>
 <td><p>0:1</p>
-<p><span class="hl">1:1</span></p></td>
+<p><mark>1:1</mark></p></td>
 <td><p>Temps de correspondance moyen (entre l'arrivée de l'amenant et le départ du partant)</p>
-<p><span class="hl">Obligatoire dans le cadre du profil.</span></p>
-<p><span class="hl">Voir la CORRESPONDANCE physique pour les détails de temps de parcours de la correspondance (temps de marche, etc.) (</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx Réseau</span></strong></em><span class="hl">)</span><span class="hl">.</span></p></td>
+<p><mark>Obligatoire dans le cadre du profil.</mark></p>
+<p><mark>Voir la CORRESPONDANCE physique pour les détails de temps de parcours de la correspondance (temps de marche, etc.) (<em>voir le document <strong>Profil NeTEx Réseau</strong></em>).</mark></p></td>
 </tr>
 
 
@@ -1621,18 +1621,16 @@ cadences.</span>
 
 ## Position d'arrêt pour une course
 
-Cette information complète l'**Affectation de train à quai** <span
-class="hl">(</span>*<span class="hl">voir le document </span>**<span
-class="hl">Profil NeTEx Réseau</span>***<span
-class="hl">)</span><span class="hl"> </span>dans le cas où
+Cette information complète l'**Affectation de train à quai**
+<mark>(*voir le document **Profil NeTEx Réseau***)</mark> dans le cas où
 l'identification des voitures est variable d'une course à l'autre.
 
 <div class="table-title">TrainComponentLabelAssignment – Element</div>
 
 | **Classifi­cation** | **Name**                | **Type**             | **Cardin­ality** | **Description**                                                                                                                                                                                                                |
 |---------------------|-------------------------|----------------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| *::>*               | *::>*                   | *DataManagedObject*  | *::>*            | TRAIN COMPONENT LABEL ASSIGNMENT hérite de DATA MANAGED OBJECT <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span>. |
-|                     | ***Name***              | *MultilingualString* | 0:1              | Nom associé au COMPOSANT DE TRAIN (voiture) pour la course <span class="hl">(il s'agit du nom de la voiture tel qu'il figurera sur le billet du voyageur).</span>                                                            |
+| *::>*               | *::>*                   | *DataManagedObject*  | *::>*            | TRAIN COMPONENT LABEL ASSIGNMENT hérite de DATA MANAGED OBJECT <mark>(*voir le document **Profil NeTEx éléments communs***)</mark>. |
+|                     | ***Name***              | *MultilingualString* | 0:1              | Nom associé au COMPOSANT DE TRAIN (voiture) pour la course <mark>(il s'agit du nom de la voiture tel qu'il figurera sur le billet du voyageur)</mark>.                                                            |
 | «AK»                | ***VehicleJourneyRef*** | *VehicleJourneyRef*  | 0:1              | Référence de la course concernée.                                                                                                                                                                                              |
 | «FK»                | ***TrainComponentRef*** | *TrainComponentRef*  | 0:1              | Référence du COMPOSANT DE TRAIN (voiture) concernée.                                                                                                                                                                           |
 
@@ -1664,7 +1662,7 @@ l'identification des voitures est variable d'une course à l'autre.
 <td>::></td>
 <td><em>DataManagedObject</em></td>
 <td>::></td>
-<td>VEHICLE TYPE hérite de DATA MANAGED OBJECT <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>VEHICLE TYPE hérite de DATA MANAGED OBJECT <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1732,7 +1730,7 @@ l'identification des voitures est variable d'une course à l'autre.
 <td><em>PassengerCapacity</em></td>
 <td>0:*</td>
 <td><p>Capacité en passager (par classe tarifaire).</p>
-<p><span class="hl">On utilisera directement les </span><em><strong><span class="hl">PassengerCapacity</span></strong></em><span class="hl"> (et non les références) dont on n'utilisera pas les champs issu de l'héritage DATA MANAGED OBJECT.</span></p></td>
+<p><mark>On utilisera directement les <em><strong>PassengerCapacity</strong></em> (et non les références) dont on n'utilisera pas les champs issus de l'héritage DATA MANAGED OBJECT.</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1789,7 +1787,7 @@ l'identification des voitures est variable d'une course à l'autre.
 <td><em><strong><del>ClassifiedAsRef</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">On utilise le champ Brand de l'héritage DATA MANAGED OBJECT pour éventuellement indiquer la marque et/ou le modèle du véhicule.</span></td>
+<td><mark>On utilise le champ Brand de l'héritage DATA MANAGED OBJECT pour éventuellement indiquer la marque et/ou le modèle du véhicule.</mark></td>
 </tr>
 
 
@@ -1821,8 +1819,8 @@ l'identification des voitures est variable d'une course à l'autre.
 <td>::></td>
 <td><em>DataManagedObject</em></td>
 <td>::></td>
-<td><p>PASSENGER CAPACITY hérite de DATA MANAGED OBJECT <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span></p>
-<p><span class="hl">Champs non utilisés dans le cadre du profil.</span></p></td>
+<td><p>PASSENGER CAPACITY hérite de DATA MANAGED OBJECT <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</p>
+<p><mark>Champs non utilisés dans le cadre du profil.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1913,7 +1911,7 @@ l'identification des voitures est variable d'une course à l'autre.
 <td><em>TrainComponent</em></td>
 <td>0:*</td>
 <td><p>Ensemble des composants du train.</p>
-<p><span class="hl">On utilisera directement les </span><em><strong><span class="hl">TrainComponent</span></strong></em><span class="hl"> (et non les références) dont on n'utilisera pas les champs issus de l'héritage de DATA MANAGED OBJECT (à l'exception de l'identifiant, indispensable si l'on souhaite préciser les alignements de voiture sur les quais).</span></p></td>
+<p><mark>On utilisera directement les <em><strong>TrainComponent</strong></em> (et non les références) dont on n'utilisera pas les champs issus de l'héritage de DATA MANAGED OBJECT (à l'exception de l'identifiant, indispensable si l'on souhaite préciser les alignements de voiture sur les quais).</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -1941,7 +1939,7 @@ l'identification des voitures est variable d'une course à l'autre.
 <td><em><strong>NumberOfCars</strong></em></td>
 <td><em>xsd:nonNegativeInteger</em></td>
 <td>0:1</td>
-<td>Nombre de voitures <span class="hl">(voiture ou éventuellement bus couplé; par convention on indiquera 2 pour un véhicule articulé à 2 éléments).</span></td>
+<td>Nombre de voitures <mark>(voiture ou éventuellement bus couplé ; par convention on indiquera 2 pour un véhicule articulé à 2 éléments)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1982,7 +1980,7 @@ l'identification des voitures est variable d'une course à l'autre.
 <td colspan="2">::></td>
 <td><em>VersionedChild</em></td>
 <td>::></td>
-<td>TRAIN COMPONENT hérite de VERSIONED CHILD <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>TRAIN COMPONENT hérite de VERSIONED CHILD <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2003,7 +2001,7 @@ l'identification des voitures est variable d'une course à l'autre.
 <td colspan="2"><em><strong><del>TrainRef</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Non utilisé car implicite du fait de l'imbrication XML, dans le contexte du profil.</span></td>
+<td><mark>Non utilisé car implicite du fait de l'imbrication XML, dans le contexte du profil.</mark></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2012,7 +2010,7 @@ l'identification des voitures est variable d'une course à l'autre.
 <td><em><strong>TrainElement</strong></em></td>
 <td>1:1</td>
 <td><p>ELEMENT DE TRAIN associé au COMPOSANT DE TRAIN.</p>
-<p><span class="hl">On utilisera directement les </span><em><strong><span class="hl">TrainElement</span></strong></em><span class="hl"> (et non les références) dont on n'utilisera pas les champs issus de l'héritage DATA MANAGED OBJECT.</span></p></td>
+<p><mark>On utilisera directement les <em><strong>TrainElement</strong></em> (et non les références) dont on n'utilisera pas les champs issus de l'héritage DATA MANAGED OBJECT.</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -2040,8 +2038,8 @@ l'identification des voitures est variable d'une course à l'autre.
 <td>::></td>
 <td><em>DataManagedObject</em></td>
 <td>::></td>
-<td><p>TRAIN ELEMENT hérite de DATA MANAGED OBJECT <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</p>
-<p><span class="hl">Champs non utilisés dans le cadre du profil.</span></p></td>
+<td><p>TRAIN ELEMENT hérite de DATA MANAGED OBJECT <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</p>
+<p><mark>Champs non utilisés dans le cadre du profil.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>

--- a/NeTEx/parkings/index.md
+++ b/NeTEx/parkings/index.md
@@ -653,7 +653,7 @@ proposent ces colonnes :
   textes surlignés en jaune indiquent une spécificité du profil par
   rapport à NeTEx).
 
-Les textes surlignés en <span class="mark">Jaune</span> sont ceux
+Les textes surlignés en <mark>Jaune</mark> sont ceux
 présentant une particularité (spécialisation) par rapport à NeTEx: une
 codification particulière, une restriction d'usage, etc.
 
@@ -732,11 +732,11 @@ comme une zone géométrique, bordée d'un polygone.
 Une ZONE peut contenir d'autres ZONEs plus petites. Ceci est exprimé par
 la relation réflexive sur ZONE et donc un PARKING peut inclure d'autres
 PARKING comme tous les objets qui héritent de la
-<span class="mark">ZONE : dans le contexte du profil Parking , on se
+<mark>ZONE : dans le contexte du profil Parking , on se
 limitera à **3** niveaux au maximum (un PARKING de plus haut niveau,
 pouvant contenir un ou plusieurs Parkings, chacun pouvant à leur tour
 contenir un ou plusieurs Parkings mais sans pouvoir descendre plus
-« bas »).</span>
+« bas »).</mark>
 
 Une ZONE peut être représentée par un seul POINT (par l'attribut
 **Centroïd*) ***qui peut être utilisé comme une référence ponctuelle à
@@ -779,15 +779,15 @@ attributs*
 
 ### Parking
 
-<span class="mark">**\[Code PAYS\]:\[Code commune
+<mark>**\[Code PAYS\]:\[Code commune
 INSEE\]:\[Parking\]:\[Code parking spécifique\]:\[Code émetteur du code
-technique ou LOC\]**, on aura donc :</span>
+technique ou LOC\]**, on aura donc :</mark>
 
-- <span class="mark">**\[Code PAYS\]**: Identifiant du Pays en
+- <mark>**\[Code PAYS\]**: Identifiant du Pays en
   respectant la norme ISO 3166-1 (voir:
   [www.iso.org/iso/country_codes/iso_3166_code_lists.htm](http://www.iso.org/iso/country_codes/iso_3166_code_lists.htm),
-  **FR** pour la France ).</span>
-- <span class="mark">**\[Code commune INSEE\]**: 5 caractères (exemple :
+  **FR** pour la France ).</mark>
+- <mark>**\[Code commune INSEE\]**: 5 caractères (exemple :
   78297 pour Guyancourt), 2 caractères pour le département et 3 pour la
   commune elle-même en France métropolitaine et 3 2 caractères pour le
   département et 2 pour la commune elle-même pour l’outre-mer.
@@ -797,11 +797,11 @@ technique ou LOC\]**, on aura donc :</span>
   En cas de mise à jour du code commune par l’INSEE, par souci de
   pérennité de l’identifiant, on conservera le code attribué
   initialement (pas de suivi d’un éventuel changement de codification
-  INSEE donc).</span>
-- **<span class="mark">\[Type d’objet\]: Parking</span>**
-- <span class="mark">**\[Code arrêt spécifique\]** : code technique
-  libre</span>
-- <span class="mark">**\[Code émetteur du code technique\]** :
+  INSEE donc).</mark>
+- **<mark>\[Type d’objet\]: Parking</mark>**
+- <mark>**\[Code arrêt spécifique\]** : code technique
+  libre</mark>
+- <mark>**\[Code émetteur du code technique\]** :
   Identifiant de l’attributeur de code technique, par exemple EFFIA,
   QParK, Indigo, Parcub, ou l’identifiant de la collectivité en charge
   du parking. **LOC** permet de préciser que l'identifiant a été défini
@@ -811,9 +811,9 @@ technique ou LOC\]**, on aura donc :</span>
   l'identifiant est local. Pour les objets faisant partie de
   référentiels partagés on peut le remplacer par un \[NomAttributaire\]
   qui le nom (ou code) du système référentiel utilisé pour attribuer
-  l’identifiant.</span>
+  l’identifiant.</mark>
 
-<span class="mark">Exemple ***FR:75105:Parking:076:LOC***</span>
+<mark>Exemple ***FR:75105:Parking:076:LOC***</mark>
 
 Pour mémoire, les élément constitutif de cet identifiant n’ont pour
 vocation que de garantir l’unicité et la pérennité quel que soit le
@@ -823,13 +823,13 @@ information figure dans les attributs des objets). En corollaire, une
 fois un identifiant attribué, il ne doit plus être modifié, même si l’un
 des constitutifs utilisé était amené à changer.
 
-<span class="mark">Note : dans le cas de parkings pour lesquels un
+<mark>Note : dans le cas de parkings pour lesquels un
 identifiant unique aurait été délivré par le Point d’accès national sous
 la forme ***INSEE-P-xxx*** (où INSEE est le code ***INSEE*** de la
 commune et ***xxx*** est le numéro d’ordre sur 3 chiffres) le code INSEE
 sera réutilisé dans la structuration ci-dessus et ***xxx*** sera utilisé
 pour le **\[Code arrêt spécifique\]**, le **\[Code émetteur du code
-technique\]** sera « **NAP** ».</span>
+technique\]** sera « **NAP** ».</mark>
 
 <div class='table-title'>Parking – Element</div>
 
@@ -2373,10 +2373,10 @@ Parking) et décrite de façon détaillée dans le profil accessibilité.
 
 </div>
 
-<span class="mark">Note : si l’on souhaite décrire les équipements de
+<mark>Note : si l’on souhaite décrire les équipements de
 recharge de de façon détaillée (types de prise, puissance, voltage,
 fabriquant, etc.), NeTEx dispose d’un ***ChargingEquipmentProfile*** qui
-n’est pas décrit ici.</span>
+n’est pas décrit ici.</mark>
 
 # Entêtes NeTEx
 
@@ -3495,7 +3495,7 @@ ceux pour lesquels des spécialisations n’ont pas été prévues.
 <td><em><strong>Name</strong></em></td>
 <td><em>MultilingualString</em></td>
 <td><p>0:1</p>
-<p><span class="mark-gray">1:1</span></p></td>
+<p><mark class="gray">1:1</mark></p></td>
 <td><p>Nom du groupe d'entité (<mark>du LIEU D'ARRÊT, de la ZONE
 D'EMBARQUEMENT, de l'ACCÈS, etc.)</mark></p>
 <p><mark>Attribut rendu obligatoire dans le cadre de ce
@@ -4486,9 +4486,9 @@ attributs retenus y sont présentés (l'affectation est très paramétrable,
 mais la grande majorité des attributs ne sont pas retenus dans le
 profil).
 
-<span class="mark">Les NoticeAssignments doivent être intégré en ligne à
+<mark>Les NoticeAssignments doivent être intégré en ligne à
 l'élément annoté et non placé séparément. Ils peuvent faire référence à
-une NOTICE déjà défini dans un NOTICE ASSIGNMENT antérieur.</span>
+une NOTICE déjà défini dans un NOTICE ASSIGNMENT antérieur.</mark>
 
 <div class='table-title'>Notice Assignment – Element</div>
 
@@ -4674,13 +4674,13 @@ recommandé (pour des raisons de cohérence) que sa valeur soit:
 
 </div>
 
-<span class="mark">Chaque fois que pour ***LimitationStatus*** la valeur
+<mark>Chaque fois que pour ***LimitationStatus*** la valeur
 "partial" est utilisée, une "***ValidityCondition-\> Description***"
 (dans l’objet ***AccessibilityAssessment***) doit être fournie en
 conséquence pour expliquer pourquoi l'accessibilité n'est que partielle
 (notez que seule la ***Description*** de la ***ValidityCondition*** peut
 être remplie). Les informations textuelles contenues doivent pouvoir
-être présentées au public sans autre modification.</span>
+être présentées au public sans autre modification.</mark>
 
 ### Nom alternatif
 
@@ -4788,8 +4788,8 @@ Paris-Bercy”), alors qu’***AlternativeText*** servira essentiellement
 pour les traductions (par exemple. “en.London”, “fr.Londres”,
 “it.Londra”, “cn.倫敦”, “ge.ლონდონი”, etc).
 
-<span class="mark">Dans le profil, **AlternativeText** sera toujours
-utilisé comme balise incluse (et non comme élément racine).</span>
+<mark>Dans le profil, **AlternativeText** sera toujours
+utilisé comme balise incluse (et non comme élément racine).</mark>
 
 <div class='table-title'>AlternativeText – XML Element</div>
 
@@ -4871,11 +4871,11 @@ etc.).
 
 | **Class.** | **Name**                   | **Type**               | **Card.** | **Description**                                                                                                                                                                                                                                                       |
 |------------|----------------------------|------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|            | ***Colour***               | *ColourValue*          | 0:1       | Couleur <span class="mark">(format RVB)</span>                                                                                                                                                                                                                        |
+|            | ***Colour***               | *ColourValue*          | 0:1       | Couleur <mark>(format RVB)</mark>                                                                                                                                                                                                                                     |
 |            | ***ColourName***           | *xsd:normalizedString* | 0:1       | Nom de la couleur                                                                                                                                                                                                                                                     |
 |            | ***BackGroundColour***     | *ColourValueType*      | 0:1       | Valeur RVB de la couleur de fond (par exemple la couleur de la ligne de transport)                                                                                                                                                                                    |
 |            | ***BackgroundColourName*** | *xsd:String*           | 0:1       | Nom de la couleur de fond dans le *ColourSystem*.                                                                                                                                                                                                                     |
-|            | ***TextColour***           | *ColourValue*          | 0:1       | Couleur du texte <span class="mark">(format RVB)</span>                                                                                                                                                                                                               |
+|            | ***TextColour***           | *ColourValue*          | 0:1       | Couleur du texte <mark>(format RVB)</mark>                                                                                                                                                                                                                            |
 |            | ***TextColourName***       | *xsd:normalizedString* | 0:1       | Nom de la couleur du texte                                                                                                                                                                                                                                            |
 |            | ***TextFont***             | *xsd:normalizedString* | 0:1       | Identifiant de la police de caractère                                                                                                                                                                                                                                 |
 |            | ***TextFontName***         | *xsd:normalizedString* | 0:1       | Nom de la police de caractère                                                                                                                                                                                                                                         |
@@ -4935,9 +4935,9 @@ etc.)</td>
 <td><em><strong>CompanyNumber</strong></em></td>
 <td><em>xsd:normalizedString</em></td>
 <td>0:1</td>
-<td><p>Numéro d'enregistrement de l'institution<span
-class="mark-gray">(type code transporteur affecté par l'AO, NAO de la
-norme 99-502 pour les AOT, etc.)</span></p>
+<td><p>Numéro d'enregistrement de l'institution<mark
+class="gray">(type code transporteur affecté par l'AO, NAO de la
+norme 99-502 pour les AOT, etc.)</mark></p>
 <p><strong><mark>Numéro SIRET (champ obligatoire) pour les exploitants
 et propriétaire de parkings.</mark></strong></p></td>
 </tr>
@@ -4991,7 +4991,7 @@ et propriétaire de parkings.</mark></strong></p></td>
 <td><em><strong>OrganisationType</strong></em></td>
 <td><em>TypeOfOrganisationEnum</em></td>
 <td><p>0:1</p>
-<p><span class="mark-gray">1:1</span></p></td>
+<p><mark class="gray">1:1</mark></p></td>
 <td><p>Type d'organisation codifié:</p>
 <ul>
 <li><strong>authority</strong> : Autorité organisatrice</li>
@@ -5013,8 +5013,8 @@ public</li>
 <td>0:*</td>
 <td><p>Ensemble des entités constituant ou faisant partie de
 l'INSTITUTION (UNITÉ ORGANISATIONELLE ou DÉPARTEMENT).</p>
-<p><span class="mark-gray">Seules les UNITÉs ORGANISATIONELLEs seront
-utilisées dans le cadre des profils NeTEx.</span></p></td>
+<p><mark class="gray">Seules les UNITÉs ORGANISATIONELLEs seront
+utilisées dans le cadre des profils NeTEx.</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -5066,9 +5066,9 @@ utilisées dans le cadre des profils NeTEx.</span></p></td>
 <td><em>VersionedChild</em></td>
 <td></td>
 <td><p>RESPONSIBILITY ROLE hérite de VERSIONED CHILD.</p>
-<p><span class="mark-gray">Non utilisé quand inclus comme roles de
+<p><mark class="gray">Non utilisé quand inclus comme roles de
 <em><strong>ResponsabilitySet</strong> (l’inclusion est la solution
-retenue par le profil)</em></span></p></td>
+retenue par le profil)</em></mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -5118,8 +5118,8 @@ possibles sont :</p>
 <td><em>TypeOfResponsibility RoleRef</em></td>
 <td></td>
 <td><p>Référence à un type de responsabilité.</p>
-<p><span class="mark-gray">On utilisera notamment ce champ pour
-référencer un type de contrat quand cela est nécessaire.</span></p></td>
+<p><mark class="gray">On utilisera notamment ce champ pour
+référencer un type de contrat quand cela est nécessaire.</mark></p></td>
 </tr>
 <tr class="even">
 <td>« FK »</td>
@@ -6533,8 +6533,7 @@ tarifs</td>
 </div>
 
 <style>
-  .mark      { background-color: yellow; }
-  .mark-gray { background-color: lightgray; }
+  mark.gray { background-color: lightgray; }
 
   .red { color: red; }
 

--- a/NeTEx/reseaux/index.md
+++ b/NeTEx/reseaux/index.md
@@ -800,7 +800,7 @@ proposent ces colonnes:
     les textes surlignés en jaune indiquent une spécificité du profil
     par rapport à NeTEx).
 
-Les textes surlignés en <span class="hl">Jaune</span> sont ceux
+Les textes surlignés en <mark>Jaune</mark> sont ceux
 présentant une particularité (spécialisation) par rapport à NeTEx: une
 codification particulière, une restriction d'usage, etc.
 
@@ -927,7 +927,7 @@ de nuit, etc.).
 <td colspan="2"><em>::></em></td>
 <td><em>DataManagedObject</em></td>
 <td><em>::></em></td>
-<td>LINE hérite de <em><strong>DataManagedObject</strong></em> <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">).</span></td>
+<td>LINE hérite de <em><strong>DataManagedObject</strong></em> <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -977,8 +977,8 @@ de nuit, etc.).
 <td><em>xsd:normalizedString</em></td>
 <td>0:1</td>
 <td><p>Identifiant publique de la LIGNE.</p>
-<p><span class="hl">Il s'agit généralement d'un numéro, parfois complété d'une lettre (par exemple 95, ou 27A, etc.).</span> Les <em><strong><span class="hl">Name</span></strong></em><span class="hl"> et </span><em><strong><span class="hl">ShortName</span></strong></em><span class="hl"> porteront généralement une information plus explicite (par exemple la ligne ayant le </span><em><strong><span class="hl">PublicCode</span></strong></em><span class="hl"> </span><em><span class="hl">95</span></em><span class="hl"> à Paris s'appelle "</span><em><span class="hl">Porte de Vanves / Porte de Montmartre"</span></em><span class="hl">).</span></p>
-<p><span class="hl">On peut considérer que le nom complet de la ligne est une concaténation de son </span><em><strong><span class="hl">PublicCode</span></strong></em><span class="hl"> et de son </span><em><strong><span class="hl">Name</span></strong></em><span class="hl">.</span></p></td>
+<p><mark>Il s'agit généralement d'un numéro, parfois complété d'une lettre (par exemple 95, ou 27A, etc.). Les <em><strong>Name</strong></em> et <em><strong>ShortName</strong></em> porteront généralement une information plus explicite (par exemple la ligne ayant le <em><strong>PublicCode</strong></em> <em>95</em> à Paris s'appelle <em>"Porte de Vanves / Porte de Montmartre"</em>).</mark></p>
+<p><mark>On peut considérer que le nom complet de la ligne est une concaténation de son <em><strong>PublicCode</strong></em> et de son <em><strong>Name</strong></em>.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«AK»</td>
@@ -986,7 +986,7 @@ de nuit, etc.).
 <td><em>xsd:normalizedString</em></td>
 <td>0:1</td>
 <td><p>Identifiant secondaire de la LIGNE.</p>
-<p><span class="hl">Il s'agit généralement d'un identifiant propre au fournisseur (transporteur) de l'information.</span></p></td>
+<p><mark>Il s'agit généralement d'un identifiant propre au fournisseur (transporteur) de l'information.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -1008,14 +1008,14 @@ de nuit, etc.).
 <td colspan="2"><em><strong>additional­Operators</strong></em></td>
 <td><em>OperatorRef</em></td>
 <td>0:*</td>
-<td>Réference un EXPLOITANT additionnel pour la LIGNE <span class="hl">(comme pour les RER A et B à Paris, où encore les lignes en "pool").</span></td>
+<td>Réference un EXPLOITANT additionnel pour la LIGNE <mark>(comme pour les RER A et B à Paris, où encore les lignes en "pool")</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
 <td colspan="2"><em><strong>otherModes</strong></em></td>
 <td><em>modeRefs</em></td>
 <td></td>
-<td>Réference un MODE de transport additionnel pour la LIGNE <span class="hl">(certaine ligne SNCF sont parfois ponctuellement remplacées par des lignes de car par exemple).</span></td>
+<td>Réference un MODE de transport additionnel pour la LIGNE <mark>(certaines lignes SNCF sont parfois ponctuellement remplacées par des lignes de car par exemple)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1023,10 +1023,10 @@ de nuit, etc.).
 <td><em>TypeOfLineRef</em></td>
 <td>0:1</td>
 <td><p>TYPE DE LIGNE spécifique.</p>
-<p><span class="hl">Permet une classification particulière de la ligne (ligne saisonnière, ligne de substitution, etc.)</span></p>
-<p><span class="hl">Deux types prédéfinis sont proposé par le profil: SEASONAL_LINE_TYPE et REPLACEMENT_LINE_TYPE Pour ce second type on utilisera, par convention, le derivedFromObjectRef (voir le document Profil NeTEx éléments communs) pour effectuer le lien avec la ligne à remplacer, et on renseignera le ValidityTrigger permettant de décrire dans quelle condition le remplacement est activé.</span></p>
-<p><span class="hl">À ne pas confondre avec une marque commerciale, pour lequel l'attribut Branding est disponible dans le DataManagedObject (voir le document Profil NeTEx éléments communs).</span></p>
-<p><span class="hl">A définir par un TYPE DE VALEUR spécifique (</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">).</span></p></td>
+<p><mark>Permet une classification particulière de la ligne (ligne saisonnière, ligne de substitution, etc.)</mark></p>
+<p><mark>Deux types prédéfinis sont proposé par le profil : SEASONAL_LINE_TYPE et REPLACEMENT_LINE_TYPE. Pour ce second type on utilisera, par convention, le derivedFromObjectRef (voir le document Profil NeTEx éléments communs) pour effectuer le lien avec la ligne à remplacer, et on renseignera le ValidityTrigger permettant de décrire dans quelle condition le remplacement est activé.</mark></p>
+<p><mark>À ne pas confondre avec une marque commerciale, pour lequel l'attribut Branding est disponible dans le DataManagedObject (voir le document Profil NeTEx éléments communs).</mark></p>
+<p><mark>A définir par un TYPE DE VALEUR spécifique (<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>).</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1047,7 +1047,7 @@ de nuit, etc.).
 <td colspan="2"><em><strong><del>RepresentBy­GroupRef</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Le GROUPE DE LIGNES référence les LIGNES, mais on n'utilise pas la relation inverse dans le profil.</span></td>
+<td><mark>Le GROUPE DE LIGNES référence les LIGNES, mais on n'utilise pas la relation inverse dans le profil.</mark></td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>
@@ -1061,7 +1061,7 @@ de nuit, etc.).
 <td colspan="2"><em><strong>Accessibility­Assessment</strong></em></td>
 <td><em>Accessibility­Assessment</em></td>
 <td>0:1</td>
-<td>Information concernant l'accessibilité de la ligne <span class="hl">(<em>voir la partie Accessibilité du profil France</em>).</span></td>
+<td>Information concernant l'accessibilité de la ligne <mark>(<em>voir la partie Accessibilité du profil France</em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
@@ -1076,7 +1076,7 @@ de nuit, etc.).
 <td><em>noticeAssignments_RelStructure</em></td>
 <td>0:*</td>
 <td><p>NOTEs affectées à la LIGNE.</p>
-<p><span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">).</span></p></td>
+<p><mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>).</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
@@ -1094,7 +1094,7 @@ de nuit, etc.).
 
 | **Classifi­cation** | **Name**                    | **Type**            | **Cardin­ality** | **Description**                                                                                                                                                                                  |
 |---------------------|-----------------------------|---------------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| *::>*               | *::>*                       | *TypeOfValue*       | *::>*            | DIRECTION hérite de TYPE OF VALUE <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span> |
+| *::>*               | *::>*                       | *TypeOfValue*       | *::>*            | DIRECTION hérite de TYPE OF VALUE <mark>(*voir le document **Profil NeTEx éléments communs***)</mark>. |
 |                     | ***DirectionType***         | *DirectionTypeEnum* | 0:1              | Valeur fixe parmi : ‘*outbound’, ‘inbound’, ‘clockwise’, ‘anticlockwise’* (sortant, entrant, horaire, antihoraire) associée à cette DIRECTION.                                                   |
 | «FK»                | ***Opposite­DirectionRef*** | *DirectionRef*      | 0:1              | Référence à la DIRECTION correspondant au sens opposé.                                                                                                                                           |
 
@@ -1123,8 +1123,8 @@ de nuit, etc.).
 <td><em>::></em></td>
 <td><em>GroupOfEntities</em></td>
 <td><em>::></em></td>
-<td><p>GROUP OF LINEs hérite de GROUP OF ENTITies.<span class="hl"> </span><span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span></p>
-<p><span class="hl">L'attribut </span><em><strong><span class="hl">PurposeofGroupingRef</span></strong></em><span class="hl"> pourra être utilisé pour qualifier les lignes administratives en utilisant la valeur "</span><em><strong><span class="hl">administrativeLine</span></strong></em><span class="hl">".</span></p></td>
+<td><p>GROUP OF LINEs hérite de GROUP OF ENTITies <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</p>
+<p><mark>L'attribut <em><strong>PurposeofGroupingRef</strong></em> pourra être utilisé pour qualifier les lignes administratives en utilisant la valeur <em><strong>"administrativeLine"</strong></em>.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«cntd»</td>
@@ -1193,16 +1193,13 @@ Exemple :
 <!-- avec le groupe de lignes G1 qui contient des références aux lignes L1 et L2, et le groupe de lignes G2 qui contient une référence à la ligne L3. -->
 ```
 
-
-
-
 ## Zone tarifaire
 
 <div class="table-title">TariffZone – Element</div>
 
 | **Classifi­cation** | **Name** | **Type** | **Cardin­ality** | **Description**                                                                                                                                                                                                                   |
 |---------------------|----------|----------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ::>                 | ::>      | *Zone*   | ::>              | TARIFF ZONE hérite de ZONE.<span class="hl"> (</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span> sans y apporter de nouveaux attributs. |
+| ::>                 | ::>      | *Zone*   | ::>              | TARIFF ZONE hérite de ZONE <mark>(*voir le document **Profil NeTEx éléments communs***)</mark> sans y apporter de nouveaux attributs. |
 
 ## Les itinéraires
 
@@ -1210,7 +1207,7 @@ Exemple :
 
 | **Classifi­cation** | **Name**               | **Type**              | **Cardin­ality** | **Description**                                                                                                                                                                               |
 |---------------------|------------------------|-----------------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| *::>*               | *::>*                  | *LinkSequence*        | *::>*            | ROUTE hérite de LINK SEQUENCE <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span>. |
+| *::>*               | *::>*                  | *LinkSequence*        | *::>*            | ROUTE hérite de LINK SEQUENCE <mark>(voir le document **Profil NeTEx éléments communs***)</mark>. |
 | «FK»                | ***LineRef***          | *LineRef*             | 0:1              | LIGNE à laquelle l'ITINÉRAIRE appartient.                                                                                                                                                     |
 |                     | ***DirectionType***    | *TypeOfDirectionEnum* | 0:1              | Type de direction de la ROUTE (***outbound***, ***inbound***, pour aller Retrour et éventuellement ***clockwise*** ou ***anticlockwise*** pour les boucles)                                   |
 | «FK»                | ***DirectionRef***     | *DirectionRef*        | 0:1              | Référence la DIRECTION de l'ITINÉRAIRE.                                                                                                                                                       |
@@ -1224,7 +1221,7 @@ Exemple :
 
 | **Classifi­cation** | **Name**             | **Type**      | **Cardin­ality** | **Description**                                                                                                                                                                             |
 |---------------------|----------------------|---------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| *::>*               | *::>*                | *Point*       | *::>*            | ROUTE POINT hérite de POINT <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span>. |
+| *::>*               | *::>*                | *Point*       | *::>*            | ROUTE POINT hérite de POINT <mark>(*voir le document **Profil NeTEx éléments communs***)</mark>. |
 |                     | ***BorderCrossing*** | *xsd:boolean* | 0:1              | Indique que le point est un point situé à la frontière entre deux pays.                                                                                                                     |
 
 ### Les points sur itinéraire
@@ -1233,9 +1230,9 @@ Exemple :
 
 | **Classifi­cation**           | **Name**            |                    | **Type**              | **Cardin­ality** | **Description**                                                                                                                                                                                                 |
 |-------------------------------|---------------------|--------------------|-----------------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| *::>*                         | *::>*               |                    | *PointInLinkSequence* | *::>*            | POINT ON ROUTE hérite de POINT IN LINK SEQUENCE <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span>. |
-| *Hérité de POINT IN SEQUENCE* |                     | ***~~RouteRef~~*** |                       |                  | <span class="hl">Les PointOnRoute seront systématiquement inclus dans les ROUTEs</span>                                                                                                                       |
-|                               |                     | ***projections***  | *projections*         | 0:1              | Projection sur la voirie ou les rails <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span>.           |
+| *::>*                         | *::>*               |                    | *PointInLinkSequence* | *::>*            | POINT ON ROUTE hérite de POINT IN LINK SEQUENCE <mark>(*voir le document **Profil NeTEx éléments communs***)</mark>.                                                                                            |
+| *Hérité de POINT IN SEQUENCE* |                     | ***~~RouteRef~~*** |                       |                  | <mark>Les PointOnRoute seront systématiquement inclus dans les ROUTEs.</mark>                                                                                                                                   |
+|                               |                     | ***projections***  | *projections*         | 0:1              | Projection sur la voirie ou les rails <mark>(*voir le document **Profil NeTEx éléments communs***)</mark>.                                                                                                      |
 | «FK»                          | ***RoutePointRef*** |                    | *RoutePointRef*       | 1:1              | Référence au POINT D'ITINÉRAIRE correspondant                                                                                                                                                                   |
 
 #### Point sur séquence de tronçon
@@ -1244,10 +1241,10 @@ Exemple :
 
 | **Classifi­cation** | **Name**              | **Type**              | **Cardin­ality** | **Description**                                                                                                                                                                                                        |
 |---------------------|-----------------------|-----------------------|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| *::>*               | *::>*                 | *PointInSequence*     | *::>*            | POINT IN LINK SEQUENCE hérite de ***PointInSequence*** <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span>. |
+| *::>*               | *::>*                 | *PointInSequence*     | *::>*            | POINT IN LINK SEQUENCE hérite de ***PointInSequence*** <mark>(*voir le document **Profil NeTEx éléments communs***)</mark>.                                                                                            |
 |                     | ***order***           | *xsd:positiveInteger* | 0:1              | Numéro d'ordre du point dans la séquence.                                                                                                                                                                              |
-|                     | ***LinkSequenceRef*** | *LinkSequenceRef*     | 0:1              | Référence la SÉQUENCE DE TRONÇONs à laquelle appartient le POINT <span class="hl">(une spécialisation pourra intervenir via un groupe de substitution).</span>                                                       |
-|                     | ***projections***     | *projections*         | 0:1              | Projection sur la voirie ou les rails <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span>.                  |
+|                     | ***LinkSequenceRef*** | *LinkSequenceRef*     | 0:1              | Référence la SÉQUENCE DE TRONÇONs à laquelle appartient le POINT <mark>(une spécialisation pourra intervenir via un groupe de substitution)</mark>.                                                                    |
+|                     | ***projections***     | *projections*         | 0:1              | Projection sur la voirie ou les rails <mark>(*voir le document **Profil NeTEx éléments communs***)</mark>.                                                                                                             |
 
 ### Les tronçons d'itinéraire
 
@@ -1255,12 +1252,11 @@ Exemple :
 
 | **Classifi­cation** | **Name**           | **Type**        | **Cardin­ality** | **Description**                                                                                                                                                                           |
 |---------------------|--------------------|-----------------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| *::>*               | *::>*              | *Link*          | *::>*            | ROUTE LINK hérite de LINK <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">)</span>. |
+| *::>*               | *::>*              | *Link*          | *::>*            | ROUTE LINK hérite de LINK <mark>(*voir le document **Profil NeTEx éléments communs***)</mark>.                                                                                            |
 |                     | Distance           | DistanceType    | 1:1              | Longueur du ROUTE LINK. Les unités sont telles que spécifiées pour la FRAME (la valeur par défaut est SI mètres).                                                                         |
 | «cntd»              | LineString         | gmlLineString   | 0:1              | Géométrie du TRONÇON sous forme d’une linestring GML (la géométrie d’un TRONÇON n’est donc pas limitée à un simple couple de point, mais est décrite par une séquence de points).  |
-| «FK»                | ***FromPointRef*** | *RoutePointRef* | 1:1              | POINT D'ITINÉRAIRE de début de <span class="hl">TRONÇON</span>.                                                                                                                         |
-| «FK»                | ***ToPointRef***   | *RoutePointRef* | 1:1              | POINT D'ITINÉRAIRE de fin de <span class="hl">TRONÇON</span>.                                                                                                                           |
-|                     |                    |                 |                  |                                                                                                                                                                                           |
+| «FK»                | ***FromPointRef*** | *RoutePointRef* | 1:1              | POINT D'ITINÉRAIRE de début de <mark>TRONÇON</mark>.                                                                                                                                      |
+| «FK»                | ***ToPointRef***   | *RoutePointRef* | 1:1              | POINT D'ITINÉRAIRE de fin de <mark>TRONÇON</mark>.                                                                                                                                        |
 
 Exemple de LineString pour décrire un tracé : 
 ```xml
@@ -1299,7 +1295,7 @@ Exemple de LineString pour décrire un tracé :
 <td><em>::></em></td>
 <td><em>DataManagedObject</em></td>
 <td><em>::></em></td>
-<td>DESTINATION DISPLAY hérite de <em><strong>DataManagedObject</strong></em> <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>DESTINATION DISPLAY hérite de <em><strong>DataManagedObject</strong></em> <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 
 
@@ -1315,9 +1311,9 @@ Exemple de LineString pour décrire un tracé :
 <td><em><strong>FrontText</strong></em></td>
 <td><em>MultilingualString</em></td>
 <td><p>0:1</p>
-<p><span class="hl">1:1</span></p></td>
+<p><mark>1:1</mark></p></td>
 <td><p>Texte frontal (affiché sur le devant du véhicule) de l'AFFICHAGE DE DESTINATION.</p>
-<p><span class="hl">Au niveau du profil, ce texte est considéré comme étant le texte principal et est rendu obligatoire.</span></p></td>
+<p><mark>Au niveau du profil, ce texte est considéré comme étant le texte principal et est rendu obligatoire.</mark></p></td>
 </tr>
 
 
@@ -1327,7 +1323,7 @@ Exemple de LineString pour décrire un tracé :
 <td><em>xsd:normalizedString</em></td>
 <td>0:1</td>
 <td><p>Code associé à l'AFFICHAGE DE DESTINATION.</p>
-<p><span class="hl">Dans un certain nombre de cas l'AFFICHAGE DE DESTINATION n'est pas un texte mais un code (par exemple pour les RER et Transilen en IIe-de-France avec des codes comme PADO, DEFI ou encore PORO). Ce sont ces codes qui seront indiqué dans ce champ (on réservera les champs </span><em><strong><span class="hl">XxxxText</span></strong></em><span class="hl"> pour un texte compréhensible par tous)</span>.</p></td>
+<p><mark>Dans un certain nombre de cas l'AFFICHAGE DE DESTINATION n'est pas un texte mais un code (par exemple pour les RER et Transilen en IIe-de-France avec des codes comme PADO, DEFI ou encore PORO). Ce sont ces codes qui seront indiqué dans ce champ (on réservera les champs <em><strong>XxxxText</strong></em> pour un texte compréhensible par tous).</mark></p></td>
 </tr>
 
 <tr class="odd">
@@ -1335,7 +1331,7 @@ Exemple de LineString pour décrire un tracé :
 <td><em><strong><del>vias</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Les éventuels vias seront intégrés dans le texte de l'AFFICHAGE DE DESTINATION.</span></td>
+<td><mark>Les éventuels vias seront intégrés dans le texte de l'AFFICHAGE DE DESTINATION.</mark></td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>
@@ -1372,7 +1368,7 @@ Exemple de LineString pour décrire un tracé :
 <td><em>::></em></td>
 <td><em>DataManagedObject</em></td>
 <td><em>::></em></td>
-<td>DESTINATION DISPLAY VARIANT hérite de <em><strong>DataManagedObject</strong></em> <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>DESTINATION DISPLAY VARIANT hérite de <em><strong>DataManagedObject</strong></em> <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 
 <tr class="even">
@@ -1397,9 +1393,9 @@ Exemple de LineString pour décrire un tracé :
 <td><em><strong>FrontText</strong></em></td>
 <td><em>MultilingualString</em></td>
 <td><p>0:1</p>
-<p><span class="hl">1:1</span></p></td>
+<p><mark>1:1</mark></p></td>
 <td><p>Texte "frontal" de la VARIANTE D'AFFICHAGE DE DESTINATION.</p>
-<p><span class="hl">Au niveau du profil, ce texte est considéré comme étant le texte principal et est rendu obligatoire.</span></p></td>
+<p><mark>Au niveau du profil, ce texte est considéré comme étant le texte principal et est rendu obligatoire.</mark></p></td>
 </tr>
 
 
@@ -1458,7 +1454,7 @@ flexibilité.
 <td><em><strong>FlexibleLineType</strong></em></td>
 <td><em>FlexibleLineTypeEnum</em></td>
 <td>1:1</td>
-<td><p>Type de LIGNE FLEXIBLE <span class="hl">(voir le document NeTEx pour le détail des différents types de flexibilité)</span>:</p>
+<td><p>Type de LIGNE FLEXIBLE <mark>(voir le document NeTEx pour le détail des différents types de flexibilité)</mark> :</p>
 <ul>
 <li><p><em>corridorService</em></p></li>
 <li><p><em>mainRouteWithFlexibleEnds</em></p></li>
@@ -1505,7 +1501,7 @@ flexibilité.
 <td><em><strong>BookingContact</strong></em></td>
 <td><em>ContactDetails</em></td>
 <td>0:1</td>
-<td>Informations de contact pour la réservation <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>Informations de contact pour la réservation <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1569,7 +1565,7 @@ flexibilité.
 <td>MultilingualString</td>
 <td>0:1</td>
 <td><p>Heure au plus tard, dans la journée, où la réservation doit se faire.</p>
-<p><span class="hl">A combiner avec </span><em><strong><span class="hl">BookWhen </span></strong></em><span class="hl">pour exprimer, par exemple </span><em><span class="hl">"avant la veille à 18:00"</span>.</em></p></td>
+<p><mark>À combiner avec <em><strong>BookWhen></strong></em> pour exprimer, par exemple <em>"avant la veille à 18:00"</em>.</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1583,7 +1579,7 @@ flexibilité.
 <td><em><strong><del>BookingUrl</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">On utilise l'URL de bookingContact</span></td>
+<td><mark>On utilise l'URL de bookingContact</mark></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1627,7 +1623,7 @@ flexibilité.
 <td><em><strong>FlexibleRoute­Type</strong></em></td>
 <td><em>FlexibleRouteTypeEnum</em></td>
 <td>1:1</td>
-<td><p>Type d'ITINÉRAIRE FLEXIBLE <em><span class="hl">(voir le document NeTEx pour les définitions)</span></em> :</p>
+<td><p>Type d'ITINÉRAIRE FLEXIBLE <mark><em>(voir le document NeTEx pour les définitions)</em></mark> :</p>
 <ul>
 <li><p><em>flexibleAreasOnly</em></p></li>
 <li><p><em>hailAndRideSections</em></p></li>
@@ -1668,7 +1664,7 @@ flexibilité.
 <td colspan="2"><em>::></em></td>
 <td><em>VersionedChild</em></td>
 <td><em>::></em></td>
-<td><em><strong>FlexiblePointProperties</strong></em> hérite de <strong><em>VersionedChild</em></strong> <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td><em><strong>FlexiblePointProperties</strong></em> hérite de <strong><em>VersionedChild</em></strong> <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td>Choice</td>
@@ -1706,7 +1702,7 @@ flexibilité.
 <td><em>xsd:boolean</em></td>
 <td>0:1</td>
 <td><p>Point représentant une ZONE</p>
-<p>Le POINT est alors obligatoirement référencé par une ZONE dont il est le centroïd <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</p></td>
+<p>Le POINT est alors obligatoirement référencé par une ZONE dont il est le centroïd <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -1743,7 +1739,7 @@ flexibilité.
 <td><em>::></em></td>
 <td><em>VesionedChild</em></td>
 <td><em>::></em></td>
-<td><em><strong>FlexibleLinkProperties</strong></em> hérite de <strong><em>VesionedChild</em></strong> <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td><em><strong>FlexibleLinkProperties</strong></em> hérite de <strong><em>VesionedChild</em></strong> <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1819,7 +1815,7 @@ flexibilité.
 <td><em>::></em></td>
 <td><em>LinkSequence</em></td>
 <td><em>::></em></td>
-<td>JOURNEY PATTERN hérite de LINK SEQUENCE <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>JOURNEY PATTERN hérite de LINK SEQUENCE <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td>«FK»</td>
@@ -1833,7 +1829,7 @@ flexibilité.
 <td><em><strong><del>DirectionType</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Les informations de directions seront portées par l'ITINÉRAIRE.</span></td>
+<td><mark>Les informations de directions seront portées par l'ITINÉRAIRE.</mark></td>
 </tr>
 <tr class="odd">
 <td>«FK»</td>
@@ -1841,14 +1837,14 @@ flexibilité.
 <td><em>DirectionRef</em></td>
 <td>0:1</td>
 <td>La DIRECTION d’une JOURNEY PATTERN est souvent utilisée pour distinguer des groupes de JOURNEY PATTERN utilisant les mêmes branches (c’est-à-dire des ROUTEs) d’une LIGNE.<br />
-<span class="hl">La DIRECTION est disponible à des fins de filtrage exclusivement (par exemple dans une interface utilisateur de calculateur d’itinéraire ou un système d'information sur les horaires), mais ne devra pas être considérée comme une informations descriptive (ce n’est pas une information présentée « spontanément »).</span></td>
+<mark>La DIRECTION est disponible à des fins de filtrage exclusivement (par exemple dans une interface utilisateur de calculateur d’itinéraire ou un système d'information sur les horaires), mais ne devra pas être considérée comme une informations descriptive (ce n’est pas une information présentée « spontanément »).</mark></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
 <td><em><strong>Destination­Display­Ref</strong></em></td>
 <td><em>DestinationDisplayRef</em></td>
 <td>0:1</td>
-<td>AFFICHAGE DE DESTINATION associée à la MISSION COMMERCIALE <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>AFFICHAGE DE DESTINATION associée à la MISSION COMMERCIALE <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>
@@ -1871,7 +1867,7 @@ Liste ordonnée des sections de la MISSION COMMERCIALE (SERVICE LINK). Chaque se
 <td><em>ServiceJourneyPatternTypeEnumeration</em></td>
 <td>0:1</td>
 <td><p>Type de MISSION COMMERCIALE.</p>
-<p><span class="hl">Il s'agit d'un type "étendu" qui permet de typer tout PARCOURS présentant un intérêt pour l'information voyageur.</span> Les valeurs possibles pour ce type sont:</p>
+<p><mark>Il s'agit d'un type "étendu" qui permet de typer tout PARCOURS présentant un intérêt pour l'information voyageur.</mark> Les valeurs possibles pour ce type sont :</p>
 <ul>
 <li><p><em>Passenger</em> : service passager</p></li>
 <li><p><em>garageRunOut</em> : sortie de garage/dépôt</p></li>
@@ -1917,15 +1913,15 @@ manœuvre de retournement).
 <td><em>::></em></td>
 <td><em>PointInLinkSequence</em></td>
 <td><em>::></em></td>
-<td><p>POINT IN JOURNEY PATTERN hérite de POINT IN LINK SEQUENCE <span class="hl">(voir )</span></p>
-<p><span class="hl">On n'utilisera pas le </span><em><strong><span class="hl">LinkSequenceRef</span></strong></em><span class="hl"> de cet héritage car, dans le contexte du profil, cet objet sera toujours "à l'intérieur" d'une MISSION COMMERCIALE.</span></p></td>
+<td><p>POINT IN JOURNEY PATTERN hérite de POINT IN LINK SEQUENCE <mark>(voir )</mark></p>
+<p><mark>On n'utilisera pas le <em><strong>LinkSequenceRef</strong></em> de cet héritage car, dans le contexte du profil, cet objet sera toujours "à l'intérieur" d'une MISSION COMMERCIALE.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«FK»</td>
 <td><em><strong>PointRef</strong></em></td>
 <td><em>PointRef</em></td>
 <td>0:1</td>
-<td>POINT à placer dans le PARCOURS <span class="hl">(il peut s'agir de n'importe quel type de point).</span></td>
+<td>POINT à placer dans le PARCOURS <mark>(il peut s'agir de n'importe quel type de point)</mark>.</td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -1933,7 +1929,7 @@ manœuvre de retournement).
 <td><em>DestinationDisplayRef</em></td>
 <td>0:1</td>
 <td><p>DESTINATION DISPLAY associée à ce POINT.</p>
-<p><span class="hl">Cette information, qui sert à changer l'AFFICHAGE DE DESTINATION lorsque le véhicule arrive à ce POINT ne sera renseignée que si </span><em><strong><span class="hl">ChangeOfDestinationDisplay</span></strong></em><span class="hl"> est VRAI</span></p></td>
+<p><mark>Cette information, qui sert à changer l'AFFICHAGE DE DESTINATION lorsque le véhicule arrive à ce POINT ne sera renseignée que si <em><strong>ChangeOfDestinationDisplay</strong></em> est VRAI</mark></p></td>
 </tr>
 
 <tr class="even">
@@ -1941,7 +1937,7 @@ manœuvre de retournement).
 <td><em><strong>FlexiblePointProperties</strong></em></td>
 <td><em>FlexiblePointProperties</em></td>
 <td>0:1</td>
-<td>Information sur l'éventuelle flexibilité du POINT <span class="hl">(voir )</span></td>
+<td>Information sur l'éventuelle flexibilité du POINT <mark>(voir )</mark></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -1980,8 +1976,8 @@ manœuvre de retournement).
 <td><em>::></em></td>
 <td><em>TimingPointInJourneyPattern</em></td>
 <td><em>::></em></td>
-<td><p>STOP POINT IN JOURNEY PATTERN hérite de POINT IN LINK SEQUENCE <span class="hl">(voir )</span></p>
-<p><span class="hl">On n'utilisera pas le </span><em><strong><span class="hl">LinkSequenceRef</span></strong></em><span class="hl"> de cet héritage car, dans le contexte du profil, cet objet sera toujours "à l'intérieur" d'une MISSION COMMERCIALE.</span></p></td>
+<td><p>STOP POINT IN JOURNEY PATTERN hérite de POINT IN LINK SEQUENCE <mark>(voir )</mark></p>
+<p><mark>On n'utilisera pas le <em><strong>LinkSequenceRef</strong></em> de cet héritage car, dans le contexte du profil, cet objet sera toujours "à l'intérieur" d'une MISSION COMMERCIALE.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«FK»</td>
@@ -1990,8 +1986,6 @@ manœuvre de retournement).
 <td>1:1</td>
 <td>Reference au POINT D'ARRÊT PLANIFIÉ.</td>
 </tr>
-
-
 
 <tr class="odd">
 <td></td>
@@ -2013,16 +2007,15 @@ manœuvre de retournement).
 <td><em>DestinationDisplayRef</em></td>
 <td>0:1</td>
 <td><p>DESTINATION DISPLAY associée ce POINT.</p>
-<p><span class="hl">Cette information, qui sert à changer l'AFFICHAGE DE DESTINATION lorsque le véhicule arrive à ce POINT ne sera renseignée que si </span><em><strong><span class="hl">ChangeOfDestinationDisplay</span></strong></em><span class="hl"> est VRAI</span></p></td>
+<p><mark>Cette information, qui sert à changer l'AFFICHAGE DE DESTINATION lorsque le véhicule arrive à ce POINT ne sera renseignée que si <em><strong>ChangeOfDestinationDisplay</strong></em> est VRAI</mark></p></td>
 </tr>
-
 
 <tr class="even">
 <td></td>
 <td><em><strong>FlexiblePointProperties</strong></em></td>
 <td><em>FlexiblePointProperties</em></td>
 <td>0:1</td>
-<td>Information sur l'éventuelle flexibilité du POINT <span class="hl">(voir )</span></td>
+<td>Information sur l'éventuelle flexibilité du POINT <mark>(voir )</mark></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2044,7 +2037,7 @@ manœuvre de retournement).
 <td><em><strong>RequestStop</strong></em></td>
 <td><em>xsd:boolean</em></td>
 <td>0:1</td>
-<td>Indique que l'arrêt doit être demandé <span class="hl">(bouton à l'intérieur du véhicule et faire un signe de la main depuis le quai, ou tout autre dispositif fonctionnellement similaire potentiellement précisé ci-dessous).</span></td>
+<td>Indique que l'arrêt doit être demandé <mark>(bouton à l'intérieur du véhicule et faire un signe de la main depuis le quai, ou tout autre dispositif fonctionnellement similaire potentiellement précisé ci-dessous)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2129,7 +2122,7 @@ manœuvre de retournement).
 <td><em>MultilingualString</em></td>
 <td>0:1</td>
 <td><p>Nom abrégé du POINT D'ARRÊT PLANIFIÉ.</p>
-<p><span class="hl">Informations à garder cohérente avec le lieu d'arrêt</span>.</p></td>
+<p><mark>Informations à garder cohérente avec le lieu d'arrêt.</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -2145,7 +2138,7 @@ manœuvre de retournement).
 <td><em><strong>PublicCode</strong></em></td>
 <td><em>xsd:normalizedString</em></td>
 <td>0:1</td>
-<td>Code publique du POINT D'ARRÊT PLANIFIÉ <span class="hl">(code identifiant utilisé pour les services, par SMS par exemple)</span><span class="hl">.</span></td>
+<td>Code publique du POINT D'ARRÊT PLANIFIÉ <mark>(code identifiant utilisé pour les services, par SMS par exemple)</mark>.</td>
 </tr>
 <tr class="even">
 <td>«AK»</td>
@@ -2161,7 +2154,7 @@ manœuvre de retournement).
 <td><em><strong>StopType</strong></em></td>
 <td><em>StopPlaceTypeEnum</em></td>
 <td>0:1</td>
-<td><p><span class="hl">Type de POINT D'ARRÊT PLANIFIÉ. Ce champ n'est retenu que pour fournir une information quand l'affection au LIEU D'ARRÊT n'est pas fournie (le LIEU D'ARRÊT porte cette information de type). Si </span><em><strong><span class="hl">StopType</span></strong></em><span class="hl"> est fourni et l'affection au LIEU D'ARRÊT aussi, ces informations devront être cohérente (si ça ne l'est pas, c'est le LIEU D'ARRÊT qui sera pris comme référence).</span></p>
+<td><p><mark>Type de POINT D'ARRÊT PLANIFIÉ. Ce champ n'est retenu que pour fournir une information quand l'affection au LIEU D'ARRÊT n'est pas fournie (le LIEU D'ARRÊT porte cette information de type). Si <em><strong>StopType</strong></em> est fourni et l'affection au LIEU D'ARRÊT aussi, ces informations devront être cohérente (si ça ne l'est pas, c'est le LIEU D'ARRÊT qui sera pris comme référence).</mark></p>
 <ul>
 <li><p><em>onstreetBus (bus sur voirie)</em></p></li>
 <li><p><em>onstreetTram (Tram sur voirie)</em></p></li>
@@ -2193,28 +2186,28 @@ manœuvre de retournement).
 <td><em><strong><del>ForAlighting</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Voir </span><em><strong><span class="hl">Stop</span><span class="hl">PointInJourneyPattern</span></strong></em></td>
+<td><mark>Voir <em><strong>StopPointInJourneyPattern</em></mark></td>
 </tr>
 <tr class="even">
 <td></td>
 <td><em><strong><del>ForBoarding</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Voir </span><em><strong><span class="hl">Stop</span><span class="hl">PointInJourneyPattern</span></strong></em></td>
+<td><mark>Voir <em><strong>StopPointInJourneyPattern</em></mark></td>
 </tr>
 <tr class="odd">
 <td></td>
 <td><em><strong><del>RequestStop</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Voir </span><em><strong><span class="hl">Stop</span><span class="hl">PointInJourneyPattern</span></strong></em></td>
+<td><mark>Voir <em><strong>StopPointInJourneyPattern</em></mark></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
 <td><em><strong><del>TopographicPlace­Ref</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Ces informations seront portées par le lieu d'arrêt.</span></td>
+<td><mark>Ces informations seront portées par le lieu d'arrêt.</mark></td>
 </tr>
 
 </tbody>
@@ -2259,8 +2252,8 @@ retenues).
 <td><em>::></em></td>
 <td><em>PointInSequence</em></td>
 <td><em>::></em></td>
-<td><p>TIMING POINT IN JOURNEY PATTERN hérite de POINT IN LINK SEQUENCE <span class="hl">(voir )</span></p>
-<p><span class="hl">On n'utilisera pas le </span><em><strong><span class="hl">LinkSequenceRef</span></strong></em><span class="hl"> de cet héritage car, dans le contexte du profil, cet objet sera toujours "à l'intérieur" d'une MISSION COMMERCIALE.</span></p></td>
+<td><p>TIMING POINT IN JOURNEY PATTERN hérite de POINT IN LINK SEQUENCE <mark>(voir )</mark></p>
+<p><mark>On n'utilisera pas le <em><strong>LinkSequenceRef</strong></em> de cet héritage car, dans le contexte du profil, cet objet sera toujours "à l'intérieur" d'une MISSION COMMERCIALE.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2314,7 +2307,7 @@ retenues).
 <td><em>::></em></td>
 <td><em>TimingPoint</em></td>
 <td><em>::></em></td>
-<td>TIMING POINT hérite de POINT<span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">)</span>.</td>
+<td>TIMING POINT hérite de POINT <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2391,7 +2384,7 @@ d'arrêts spécifique), héritant tous du concept TRANSFER.
 <td><em>TransportModeEnum</em></td>
 <td>0:1</td>
 <td><p>MODE de transport concerné par cette extrémité de correspondance.</p>
-<p><span class="hl">Cet attribut permet de particulariser les correspondances en fonction des modes de transport. Si rien n'est indiqué, tous les modes présents sont concernés. Si le mode est précisé, mais que certain modes présent n'ont pas de correspondance associée, c'est que la correspondance n'est pas possible pour ces modes.</span></p></td>
+<p><mark>Cet attribut permet de particulariser les correspondances en fonction des modes de transport. Si rien n'est indiqué, tous les modes présents sont concernés. Si le mode est précisé, mais que certain modes présent n'ont pas de correspondance associée, c'est que la correspondance n'est pas possible pour ces modes.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«FK»</td>
@@ -2428,7 +2421,7 @@ d'arrêts spécifique), héritant tous du concept TRANSFER.
 <td>::></td>
 <td><em>DataManagedObject</em></td>
 <td>::></td>
-<td>TRANSFER hérite de <em><strong>DataManagedObject</strong></em> <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">).</span></td>
+<td>TRANSFER hérite de <em><strong>DataManagedObject</strong></em> <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2443,7 +2436,7 @@ d'arrêts spécifique), héritant tous du concept TRANSFER.
 <td><em>TypeOfTransferRef</em></td>
 <td>0:1</td>
 <td><p>Type de TRANSFERT.</p>
-<p><span class="hl">Utilisé uniquement avec le code "ADVERTISED" pour signaler que la correspondance doit être affichée sur les média (information à l'arrêt).</span></p></td>
+<p><mark>Utilisé uniquement avec le code "ADVERTISED" pour signaler que la correspondance doit être affichée sur les média (information à l'arrêt).</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2464,7 +2457,7 @@ d'arrêts spécifique), héritant tous du concept TRANSFER.
 <td><em><strong><del>TransferDuration</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">Temps de correspondance total (marche plus temps d'attentes): non retenu pour le profil</span></td>
+<td><mark>Temps de correspondance total (marche plus temps d'attentes): non retenu pour le profil</mark></td>
 </tr>
 <tr class="even">
 <td>«cntd»</td>
@@ -2521,9 +2514,9 @@ d'arrêts spécifique), héritant tous du concept TRANSFER.
 <td><em><strong>DefaultDuration</strong></em></td>
 <td><em>xsd:duration</em></td>
 <td><p>0:1</p>
-<p><span class="hl">1:1</span></p></td>
+<p><mark>1:1</mark></p></td>
 <td><p>Durée par défaut (à pied)</p>
-<p><span class="hl">Obligatoire dans le contexte du profil.</span></p></td>
+<p><mark>Obligatoire dans le contexte du profil.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2538,7 +2531,7 @@ d'arrêts spécifique), héritant tous du concept TRANSFER.
 <td><em>xsd:duration</em></td>
 <td>0:1</td>
 <td><p>Durée pour un voyageur découvrant ce parcours.</p>
-<p><span class="hl">Note: on attend naturellement </span><em><strong><span class="hl">FrequentTraveller-Duration</span></strong></em><span class="hl"> <= </span><em><strong><span class="hl">DefaultDuration</span></strong></em><span class="hl"> <= </span><em><strong><span class="hl">OccasionalTraveller-Duration</span></strong></em></p></td>
+<p><mark>Note : on attend naturellement <em><strong>FrequentTraveller-Duration</strong></em> &le; <em><strong>DefaultDuration</strong></em> &le; <em><strong>OccasionalTraveller-Duration</strong></em>.</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2559,12 +2552,10 @@ EXPLOITANT ou par LIEU TOPOGRAPHIQUE (ville, arrondissement, etc.).
 Cette information est particulièrement importante pour les calculateurs
 d'itinéraire.
 
-<span class="hl">Par convention on fournira en général un
-</span>***<span class="hl">DefaultConnection</span>**<span
-class="hl"> </span>*<span class="hl">sans contrainte pour le cas
-général, et on le particularisera par des versions spécifiques par MODE
-ou par EXPLOITANT qui viendront alors "surcharger" la version sans
-contrainte (la priorité est aux versions particularisées).</span>
+<mark>Par convention on fournira en général un ***DefaultConnection*** sans
+contrainte pour le cas général, et on le particularisera par des versions
+spécifiques par MODE ou par EXPLOITANT qui viendront alors "surcharger" la
+version sans contrainte (la priorité est aux versions particularisées).</mark>
 
 <div class="table-title">DefaultConnection – Element</div>
 
@@ -2669,24 +2660,10 @@ D'EMBARQUEMENT (QUAY).
 </tr>
 <tr class="even">
 <td></td>
-<td colspan="2"></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="odd">
-<td></td>
-<td colspan="2"></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="even">
-<td></td>
 <td colspan="2"><em><strong><del>ScheduledStopPointRef</del></strong></em></td>
 <td></td>
 <td></td>
-<td><span class="hl">On limite dans le profil le SITE CONNECTION aux correspondances entre sites (LIEU D'ARRÊT, PARKING, POI) de façon à simplifier l'analyse des données et éviter toute possible confusion sémantique.</span></td>
+<td><mark>On limite dans le profil le SITE CONNECTION aux correspondances entre sites (LIEU D'ARRÊT, PARKING, POI) de façon à simplifier l'analyse des données et éviter toute possible confusion sémantique.</mark></td>
 </tr>
 <tr class="odd">
 <td>Choice</td>
@@ -2697,27 +2674,11 @@ D'EMBARQUEMENT (QUAY).
 </tr>
 <tr class="even">
 <td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="odd">
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="even">
-<td></td>
 <td><em>Choice</em></td>
 <td><em><strong>QuayRef</strong></em></td>
 <td><em>QuayRef</em></td>
 <td>0:1</td>
-<td>Référence à une ZONE D'EMBARGEMENT <span class="hl">(voir profil NeTEx Arrêt)</span></td>
+<td>Référence à une ZONE D'EMBARGEMENT <mark>(voir profil NeTEx Arrêt)</mark></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2725,7 +2686,7 @@ D'EMBARQUEMENT (QUAY).
 <td><em>StopPlaceEntranceRef</em></td>
 <td>0:1</td>
 <td><p>Référence à une entrée (entrée à utiliser pour cette correspondance)</p>
-<p><span class="hl"> (voir profil NeTEx Arrêt)</span></p></td>
+<p><mark>(voir profil NeTEx Arrêt)</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>
@@ -2733,8 +2694,8 @@ D'EMBARQUEMENT (QUAY).
 <td><em>PointOfInterestEndGroup</em></td>
 <td>0:1</td>
 <td><p>Eléments pour identifier un POI à la l’extrémité d’un SITE CONNECTION.</p>
-<p><span class="hl">On pourra utilisera </span><em><strong><span class="hl">PointOfInterestRef </span></strong></em><span class="hl">avec une référence externe.</span></p>
-<p><em><span class="hl">Note: la valeur de ce champ sera précisée quand on disposera d'un profil pour les POI</span>s.</em></p></td>
+<p><mark>On pourra utiliser <em><strong>PointOfInterestRef</strong></em> avec une référence externe.</mark></p>
+<p><mark><em>Note : la valeur de ce champ sera précisée quand on disposera d'un profil pour les POIs.</em></mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -2742,29 +2703,8 @@ D'EMBARQUEMENT (QUAY).
 <td><em>ParkingEndGroup</em></td>
 <td>0:1</td>
 <td><p>Eléments pour identifier un PARKING à l’extrémité d’un SITE CONNECTION.</p>
-<p><span class="hl">On utilisera </span><em><strong><span class="hl">PakingRef </span></strong></em><span class="hl">avec une référence externe.</span></p>
-<p><em><span class="hl">Note: la valeur de ce champ sera précisée quand on disposera d'un profil pour les PARKINGs.</span></em></p></td>
-</tr>
-<tr class="even">
-<td></td>
-<td colspan="2"></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="odd">
-<td></td>
-<td colspan="2"></td>
-<td></td>
-<td></td>
-<td></td>
-</tr>
-<tr class="even">
-<td></td>
-<td colspan="2"></td>
-<td></td>
-<td></td>
-<td></td>
+<p><mark>On utilisera <em><strong>ParkingRef</strong></em> avec une référence externe.</mark></p>
+<p><mark><em>Note : la valeur de ce champ sera précisée quand on disposera d'un profil pour les PARKINGs.</em></mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -2792,7 +2732,7 @@ utilisés pour effectuer une requête à un calculateur d’itinéraire, ils
 sont aussi utilisés pour interroger la desserte de transport
 avoisinante, etc.).
 
-<span class="hl">Dans de nombreux cas, les POIs seront définis dans des
+<mark>Dans de nombreux cas, les POIs seront définis dans des
 bases de données externes (INSPIRE, OSM, ou jeux de données commerciaux)
 et simplement référencés par SITE CONNECTIONs. Toutefois la le
 formalisme NeTEx peut aussi permettre d’enrichir l’information issue
@@ -2800,13 +2740,10 @@ d’une autre source (par exemple pour y décrire les service disponible,
 l’accessibilité, les équipements du lieu, etc.). Dans ces cas
 d’enrichissement, on prendra soin de bien conserver l’identifiant de
 l’objet enrichi et on utilisera le codespace adéquat (par exemple
-</span><span class="hl">"</span><span
-class="hl">FR_OSM:PointOfInteres:node:55711945</span><span
-class="hl">"</span><span class="hl"> où </span><span
-class="hl">55711945 </span><span class="hl">est bien d’identifiant
+"FR_OSM:PointOfInteres:node:55711945" où 55711945 est bien l’identifiant
 OSM, pour enrichir une POI issu d’Open Street Map et permet
-</span><span class="hl">node</span><span class="hl"> de qualifier le
-type d’objet OSM pour garantir l’unicité de l’identifiant)</span>
+au node de qualifier le
+type d’objet OSM pour garantir l’unicité de l’identifiant)</mark>
 
 1.  PointOfInterest – XML Element
 
@@ -2846,7 +2783,7 @@ type d’objet OSM pour garantir l’unicité de l’identifiant)</span>
 <td><em>PointOfInterest­ClassificationRef | PointOfInterestClassificationView</em></td>
 <td>0:*</td>
 <td><p>Classification du POINT OF INTEREST.</p>
-<p><span class="hl">Seul l'attribut Name de PointOfInterestClassificationView sera utilisé pour cette classification. Aucune classification standard n'est prédéfinie ni par NeTEx, ni par le profil.</span></p></td>
+<p><mark>Seul l'attribut Name de PointOfInterestClassificationView sera utilisé pour cette classification. Aucune classification standard n'est prédéfinie ni par NeTEx, ni par le profil.</mark></p></td>
 </tr>
 
 <tr class="even">
@@ -2865,8 +2802,8 @@ type d’objet OSM pour garantir l’unicité de l’identifiant)</span>
 La description du cheminement est ici limitée à ses caractéristiques
 principales (en particulier pour l'accessibilité).
 
-<span class="hl">Note : la partie Accessibilité du profil France fournit
-une vue beaucoup plus détaillée du NavigationPath.</span>
+<mark>Note : la partie Accessibilité du profil France fournit
+une vue beaucoup plus détaillée du NavigationPath.</mark>
 
 <div class="table-title">NavigationPath – Element</div>
 
@@ -2893,19 +2830,6 @@ une vue beaucoup plus détaillée du NavigationPath.</span>
 <td><em>::></em></td>
 <td>NAVIGATION PATH hérite de LINK SEQUENCE.</td>
 </tr>
-
-
-
-
-
-
-
-
-
-
-
-
-
 <tr class="even">
 <td></td>
 <td><em><strong>AccessFeature­List</strong></em></td>
@@ -3000,8 +2924,8 @@ description des ITL (Interdiction de trafic local).
 <td><em>::></em></td>
 <td><em>Zone</em></td>
 <td><em>::></em></td>
-<td><p>ROUTING CONSTRAINT ZONE hérite de ZONE <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">).</span></p>
-<p><span class="hl">Note: on définira généralement la zone par la liste des POINTs D'ARRÊT PLANIFIÉs concernés par la contrainte (une ZONE peut en effet être définie par un ensemble de points, par son attribut </span><em><strong><span class="hl">members</span></strong></em><span class="hl">). Si la ZONE n'est pas définie par un ensemble de points (et uniquement dans ce cas-là) c'est son périmètre géographique qui sera utilisé (il devra donc impérativement être défini).</span></p></td>
+<td><p>ROUTING CONSTRAINT ZONE hérite de ZONE <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</p>
+<p><mark>Note : on définira généralement la zone par la liste des POINTs D'ARRÊT PLANIFIÉs concernés par la contrainte (une ZONE peut en effet être définie par un ensemble de points, par son attribut <em><strong>>members</strong></em>). Si la ZONE n'est pas définie par un ensemble de points (et uniquement dans ce cas-là) c'est son périmètre géographique qui sera utilisé (il devra donc impérativement être défini).</mark></p></td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -3036,7 +2960,7 @@ description des ITL (Interdiction de trafic local).
 <td><em><strong>pointsInPattern</strong></em></td>
 <td><em>pointsInPattern</em></td>
 <td></td>
-<td><span class="hl">Cette propriété n'est pas retenue dans le profil France. Le champ <em>member</em> est utilisé, comme indiqué ci-dessus dans l'héritage de Zone.</span></td>
+<td><mark>Cette propriété n'est pas retenue dans le profil France. Le champ <em>member</em> est utilisé, comme indiqué ci-dessus dans l'héritage de Zone.</mark></td>
 </tr>
 </tbody>
 </table>
@@ -3066,7 +2990,7 @@ description des ITL (Interdiction de trafic local).
 <td><em>::></em></td>
 <td><em>DataManagedObject</em></td>
 <td><em>::></em></td>
-<td>TRANSFER RESTRICTION hérite de DATA MANAGED OBJECT (via ASSIGNMENT) <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">).</span></td>
+<td>TRANSFER RESTRICTION hérite de DATA MANAGED OBJECT (via ASSIGNMENT) <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 
 <tr class="even">
@@ -3093,7 +3017,7 @@ description des ITL (Interdiction de trafic local).
 <ul>
 <li><p>cannotTransfer</p></li>
 </ul>
-<p><span class="hl">Seule l'interdiction de correspondance est retenue dans le profil.</span></p></td>
+<p><mark>Seule l'interdiction de correspondance est retenue dans le profil.</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -3101,8 +3025,8 @@ description des ITL (Interdiction de trafic local).
 <td>ScheduledStopPointRef</td>
 <td>0:1</td>
 <td><p>PONT D'ARRÊT PLANIFIÉ de départ</p>
-<p><span class="hl">Si seul le départ est indiqué, toutes les correspondances partantes sont interdites (et entrante aussi si BothWays=vrai).</span></p>
-<p><span class="hl">Au moins l'un des deux attributs </span><em><strong><span class="hl">FromPointRef ou ToPointRef </span></strong></em><span class="hl">doir être valorisé.</span></p></td>
+<p><mark>Si seul le départ est indiqué, toutes les correspondances partantes sont interdites (et entrante aussi si BothWays=vrai).</mark></p>
+<p><mark>Au moins l'un des deux attributs <em><strong>FromPointRef</strong></em> ou <em><strong>ToPointRef</strong></em> doit être valorisé.</mark></p></td>
 </tr>
 <tr class="odd">
 <td>«FK»</td>
@@ -3110,8 +3034,8 @@ description des ITL (Interdiction de trafic local).
 <td>ScheduledStopPointRef</td>
 <td>0:1</td>
 <td><p>PONT D'ARRÊT PLANIFIÉ de destination.</p>
-<p><span class="hl">Si seul la destination est indiquée, toutes les correspondances arrivantes sont interdites (et sortantes aussi si BothWays=vrai).</span></p>
-<p><span class="hl">Au moins l'un des deux attributs </span><em><strong><span class="hl">FromPointRef ou ToPointRef </span></strong></em><span class="hl">doit être valorisé.</span></p></td>
+<p><mark>Si seule la destination est indiquée, toutes les correspondances arrivantes sont interdites (et sortantes aussi si BothWays=vrai).</mark></p>
+<p><mark>Au moins l'un des deux attributs <em><strong>FromPointRef</strong></em> ou <em><strong>ToPointRef</strong></em> doit être valorisé.</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -3129,7 +3053,7 @@ de du ministère des transport) et les POINTs D'ARRÊT PLANIFIÉs.
 
 | **Classifi­cation** | **Name**                     | **Type**                | **Cardin­ality** | **Description**                                                                                                                                                                                                                |
 |---------------------|------------------------------|-------------------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| *::>*               | *::>*                        | *DataManagedObject*     | *::>*            | STOP ASSIGNMENT hérite de DATA MANAGED OBJECT (via ASSIGNMENT) <span class="hl">(</span>*<span class="hl">voir le document </span>**<span class="hl">Profil NeTEx éléments communs</span>***<span class="hl">).</span> |
+| *::>*               | *::>*                        | *DataManagedObject*     | *::>*            | STOP ASSIGNMENT hérite de DATA MANAGED OBJECT (via ASSIGNMENT) <mark>(*voir le document **Profil NeTEx éléments communs***)</mark>. |
 | «FK»                | ***ScheduledStop­PointRef*** | *ScheduledStopPointRef* | 0:1              | Référence au POINT D'ARRÊT PLANIFIÉ.                                                                                                                                                                                           |
 
 <div class="table-title">PassengerStopAssignment – Element</div>
@@ -3178,7 +3102,7 @@ de du ministère des transport) et les POINTs D'ARRÊT PLANIFIÉs.
 <td><em>TrainStopAssignment</em></td>
 <td>0:*</td>
 <td><p>Références à des affectations détaillées des positions de train (alignement des voitures sur les marques à quai).</p>
-<p><span class="hl">On utilisera ici des objets indépendant (des références et non des inclusions) de façon à permettre une mise à jour de l’affectation de train, sans avoir à modifier l'affectation d'arrêt elle-même. De même on autorise que l'affectation de train référence l'affectation d'arrêt sans que la réciproque ne soit vraie (on pourra donc ne pas remplir le présent élément).</span></p></td>
+<p><mark>On utilisera ici des objets indépendant (des références et non des inclusions) de façon à permettre une mise à jour de l’affectation de train, sans avoir à modifier l'affectation d'arrêt elle-même. De même on autorise que l'affectation de train référence l'affectation d'arrêt sans que la réciproque ne soit vraie (on pourra donc ne pas remplir le présent élément).</mark></p></td>
 </tr>
 </tbody>
 </table>
@@ -3223,10 +3147,10 @@ de du ministère des transport) et les POINTs D'ARRÊT PLANIFIÉs.
 <td><em>TrainRef</em></td>
 <td>0:1</td>
 <td><p>Identifiant du train concerné.</p>
-<p><span class="hl">On pourra soit utiliser l'identifiant d'un TRAIN défini par ailleurs, soit directement référencer un numéro de train en utilisant la convention suivante:</span></p>
+<p><mark>On pourra soit utiliser l'identifiant d'un TRAIN défini par ailleurs, soit directement référencer un numéro de train en utilisant la convention suivante :</mark></p>
 <ul>
-<li><p><span class="hl">L'attribut nameOfRefClass de la référence est positionné à "TrainNumberRef"</span></p></li>
-<li><p><span class="hl">L'attribut </span><em><strong><span class="hl">ref</span></strong></em><span class="hl"> de la référence est instancié avec le numéro de train (ex: "</span><em><span class="hl">9050"</span></em><span class="hl"> pour l'Eurostar Londres-Paris de 19h01)</span></p></li>
+<li><p><mark>L'attribut nameOfRefClass de la référence est positionné à "TrainNumberRef".</mark></p></li>
+<li><p><mark>L'attribut <em><strong>ref</strong></em> de la référence est instancié avec le numéro de train (ex : <em>"9050"</em> pour l'Eurostar Londres-Paris de 19h01).</mark></p></li>
 </ul></td>
 </tr>
 <tr class="odd">
@@ -3235,10 +3159,10 @@ de du ministère des transport) et les POINTs D'ARRÊT PLANIFIÉs.
 <td><em>TrainComponenRef</em></td>
 <td>0:1</td>
 <td><p>COMPOSANT DE TRAIN (voiture) concerné par l'affectation de train.</p>
-<p><span class="hl">On pourra soit utiliser l'identifiant d'un COMPOSANT DE TRAIN défini par ailleurs, soit directement référencer un numéro de voiture en utilisant la convention suivante:</span></p>
+<p><mark>On pourra soit utiliser l'identifiant d'un COMPOSANT DE TRAIN défini par ailleurs, soit directement référencer un numéro de voiture en utilisant la convention suivante :</mark></p>
 <ul>
-<li><p><span class="hl">L'attribut nameOfRefClass de la référence est positionné à "TrainComponentRef"</span></p></li>
-<li><p><span class="hl">L'attribut </span><em><strong><span class="hl">ref</span></strong></em><span class="hl"> de la référence est instancié avec le numéro de voiture (ex: "</span><em><span class="hl">12"</span></em><span class="hl">)</span></p></li>
+<li><p><mark>L'attribut nameOfRefClass de la référence est positionné à "TrainComponentRef".</mark></p></li>
+<li><p><mark>L'attribut <em><strong>ref</strong></em> de la référence est instancié avec le numéro de voiture (ex : <em>"12"</em>).</mark></p></li>
 </ul></td>
 </tr>
 
@@ -3249,10 +3173,10 @@ de du ministère des transport) et les POINTs D'ARRÊT PLANIFIÉs.
 <td><em>BoardingPositionRef</em></td>
 <td>0:1</td>
 <td><p>Référence la POSITION D'EMBARQUEMENT avec laquelle le COMPOSANT DE TRAIN s'alignera.</p>
-<p>La POSITION D'EMBARQUEMENT n'étant pas retenue dans le profil NeTEx Arrêt, on utilisera la convention suivante:</p>
+<p>La POSITION D'EMBARQUEMENT n'étant pas retenue dans le profil NeTEx Arrêt, on utilisera la convention suivante :</p>
 <ul>
-<li><p><span class="hl">L'attribut nameOfRefClass de la référence est positionné à "BoardingPositionRef"</span></p></li>
-<li><p><span class="hl">L'attribut </span><em><strong><span class="hl">ref</span></strong></em><span class="hl"> de la référence est instancié avec le nom de la marque à quay (ex: </span><em><span class="hl">"W"</span></em><span class="hl">)</span></p></li>
+<li><p><mark>L'attribut nameOfRefClass de la référence est positionné à "BoardingPositionRef".</mark></p></li>
+<li><p><mark>L'attribut <em><strong>ref</strong></em> de la référence est instancié avec le nom de la marque à quay (ex : <em>"W"</em>).</mark></p></li>
 </ul></td>
 </tr>
 
@@ -3295,7 +3219,7 @@ de du ministère des transport) et les POINTs D'ARRÊT PLANIFIÉs.
 <td>::></td>
 <td><em>DataManagedObject</em></td>
 <td>::></td>
-<td>SCHEMATIC MAP hérite de DATA MANAGED OBJECT <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">).</span></td>
+<td>SCHEMATIC MAP hérite de DATA MANAGED OBJECT <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 <tr class="odd">
 <td></td>
@@ -3311,7 +3235,7 @@ de du ministère des transport) et les POINTs D'ARRÊT PLANIFIÉs.
 <td><em>xsd:anyURI</em></td>
 <td>0:1</td>
 <td><p>URL d'accès à la carte schématique</p>
-<p><span class="hl">La carte schématique peut être aussi bien une image raster classique (.png, .jpg, etc.), qu'une image vectorielle (.svg, .ai, etc.).</span></p></td>
+<p><mark>La carte schématique peut être aussi bien une image raster classique (.png, .jpg, etc.), qu'une image vectorielle (.svg, .ai, etc.).</mark></p></td>
 </tr>
 <tr class="even">
 <td>«FK»</td>
@@ -3353,7 +3277,7 @@ de du ministère des transport) et les POINTs D'ARRÊT PLANIFIÉs.
 <td>::></td>
 <td><em>GroupMember</em></td>
 <td>::></td>
-<td>SCHEMATIC MAP MEMBER hérite de GROUP MEMBER <span class="hl">(</span><em><span class="hl">voir le document </span><strong><span class="hl">Profil NeTEx éléments communs</span></strong></em><span class="hl">).</span></td>
+<td>SCHEMATIC MAP MEMBER hérite de GROUP MEMBER <mark>(<em>voir le document <strong>Profil NeTEx éléments communs</strong></em>)</mark>.</td>
 </tr>
 
 <tr class="even">
@@ -3371,7 +3295,7 @@ de du ministère des transport) et les POINTs D'ARRÊT PLANIFIÉs.
 <td><em>InfoLink</em></td>
 <td>0:1</td>
 <td><p>URL vers l'objet dans la carte schématique:</p>
-<p><span class="hl">On utilisera la syntaxe HTML de référencement par ancre ("anchor", avec la syntaxe </span><em><span class="hl">#anchor, </span></em><span class="hl">par exemple </span><a href="http://www.macarte.com/schma.svg#objectId"><span class="hl">http://www.macarte.com/schma.svg#objectId</span></a><span class="hl"> ) pour référencer un objet vectoriel identifié. L'URL de la carte schématique étant fournie par l'attribut </span><em><strong><span class="hl">ImageUri</span></strong></em><span class="hl">, on pourra ne fournir que la référence de l'objet (</span><em><span class="hl">#objectId</span></em><span class="hl">)</span></p></td>
+<p><mark>On utilisera la syntaxe HTML de référencement par ancre ("anchor", avec la syntaxe <em>#anchor</em>, par exemple `http://www.macarte.com/schema.svg#objectId`) pour référencer un objet vectoriel identifié. L'URL de la carte schématique étant fournie par l'attribut <em><strong>ImageUri</strong></em>, on pourra ne fournir que la référence de l'objet (<em>#objectId</em>)</mark></p></td>
 </tr>
 <tr class="even">
 <td></td>

--- a/NeTEx/tarifs/index.md
+++ b/NeTEx/tarifs/index.md
@@ -884,11 +884,11 @@ proposent ces colonnes :
   textes surlignés en jaune indiquent une spécificité du profil par
   rapport à NeTEx).
 
-Les textes surlignés en <span class="mark">jaune</span> sont ceux
+Les textes surlignés en <mark>jaune</mark> sont ceux
 présentant une particularité (spécialisation) par rapport à NeTEx : une
 codification particulière, une restriction d'usage, etc.
 
-Les textes surlignés en <span class="mark-blue">bleu</span>
+Les textes surlignés en <mark class="blue">bleu</mark>
 correspondent à des éléments de NeTEx non retenus dans le cadre de ce
 profil (présentés à titre informatif donc). Dans les diagrammes XSD, les
 éléments et attributs apparaissant sur fond bleu sont ceux qui ne sont
@@ -1461,7 +1461,7 @@ construction des structures tarifaires.
 | **Classifi­cation**  | | **Nom**                     | **Type**               | **Cardin­alité**  | **Description**                                                                            |
 | ------------------- | --- | ------------------------ | ---------------------- | ---------------- | ------------------------------------------------------------------------------------------ |
 | | ***Choice*** | | | | |
-| « FK » | ***a*** | ***GeographicalIntervalRef*** | *GeographicalIntervalRef* | 0:1 | <p>Référence au GEOGRAPHICAL INTERVAL associé au FARE STRUCTURE ELEMENT.</p><p><span class="hl">Note : de façon générale on n’utilisera les références que s’il y a effectivement réutilisation (donc ici on préférera **geographicalIntervals** à **GeographicalIntervalRef** sauf si les mêmes **GeographicalInterval** sont utilisés à plusieurs reprises)</span></p> |
+| « FK » | ***a*** | ***GeographicalIntervalRef*** | *GeographicalIntervalRef* | 0:1 | <p>Référence au GEOGRAPHICAL INTERVAL associé au FARE STRUCTURE ELEMENT.</p><p><mark>Note : de façon générale on n’utilisera les références que s’il y a effectivement réutilisation (donc ici on préférera **geographicalIntervals** à **GeographicalIntervalRef** sauf si les mêmes **GeographicalInterval** sont utilisés à plusieurs reprises)</mark></p> |
 | « cntd » | ***b*** | ***geographicalIntervals*** | <u>*GeographicalInterval*</u> / *GeographicalIntervalRef* | 0:\* | GEOGRAPHICAL INTERVALs associé au FARE STRUCTURE ELEMENT |
 | « cntd » | ***c*** | ***geographicalStructureFactors*** | <u>*GeographicalStructureFactor*</u> / *GeographicalStructureFactorRef*</td> | 0:\* | GEOGRAPHICAL STRUCTURE FACTORs associé au FARE STRUCTURE ELEMENT |
 | | ***Choice*** | | | | |
@@ -1501,10 +1501,10 @@ de la STRUCTURE FARE.
 | « PK »             | ***id***                      | *FareStructureElementInSequenceIdType* | 1:1             | Identifiant du FARE STRUCTURE ELEMENT IN SEQUENCE.                     |
 | « FK »             | ***FareStructureElementRef*** | *FareStructureElementRef*              | 0:1             | Référence à unFARE STRUCTURE ELEMENT.                                  |
 
-<span class="mark">Note : les éventuels
+<mark>Note : les éventuels
 ***ValidityParameterAssignment*** ne sont pas retenus dans le
 ***FareStructureElementInSequence*** et seront, si nécessaire, placés
-dans les ***FareStructureElement*** « hôte » de la séquence.</span>
+dans les ***FareStructureElement*** « hôte » de la séquence.</mark>
 
 <div class='table-title'>FareElementInSequence – Element</div>
 
@@ -1577,7 +1577,7 @@ une « tranche horaire » pour le voyage, par ex. aux heures de pointe ou
 aux heures creuses, et un QUOTA TARIFAIRE (FARE QUOTA FACTOR) définit
 une allocation limitée de sièges disponibles à un prix particulier.
 
-<span class="mark">Note : un ***QualityStructureFactor*** peut aussi
+<mark>Note : un ***QualityStructureFactor*** peut aussi
 être référencé par l’AFFECTATION DES PARAMÈTRES DES DROITS D'ACCÈS
 (ACCESS RIGHT PARAMETER ASSIGNMENT, plus précisément par le
 ***ValidityParameterAssignment***). On n’utilisera le
@@ -1589,7 +1589,7 @@ contre il ne s’applique que pour un ou quelques titres ou cartes de
 réduction (par exemple une carte de réduction valable uniquement en
 heures creuses), alors le ***QualityStructureFactor*** sera référencé
 par le ***ValidityParameterAssignment*** (et en cas d’ambiguïté, c’est
-cette seconde solution que l’on préférera systèmatiquement)</span>
+cette seconde solution que l’on préférera systèmatiquement)</mark>
 
 ![](media/image5.png) *QualityStructureFactor – Modèle conceptuel*
 
@@ -1600,9 +1600,9 @@ cette seconde solution que l’on préférera systèmatiquement)</span>
 | ::\>               | ::\>     | *<u>FareStructureFactor</u>*   | ::\>            | QUALITY STRUCTURE FACTOR hérite de PRICEABLE OBJECT. |
 | « PK »             | ***id*** | *QualityStructureFactorIdType* | 1:1             | Identifiant du QUALITY STRUCTURE FACTOR.             |
 
-<span class="mark">Note : dans le cas où les *QualityStructureFactor*
+<mark>Note : dans le cas où les *QualityStructureFactor*
 est très spécifique, on en effectuera la description dans une Notice
-(disponible via l’héritage PriceableObject).</span>
+(disponible via l’héritage PriceableObject).</mark>
 
 <div class='table-title'>FareStructureFactor – Element</div>
 
@@ -1613,9 +1613,9 @@ est très spécifique, on en effectuera la description dans une Notice
 |                    | ***PrivateCode***                  | *PrivateCodeStructure*                  | 0:1             | Code externe associé au facteur                          |
 |                    | ***TypeOfFareStructureFactorRef*** | *TypeOfFareStructureFactorRefStructure* | 0:1             | Référence à un TYPE OF FARE STRUCTURE FACTOR.            |
 
-<span class="mark">Note : dans le cas où les *FareStructureFactor* est
+<mark>Note : dans le cas où les *FareStructureFactor* est
 très spécifique, on en effectuera la description dans une Notice
-(disponible via l’héritage PriceableObject).</span>
+(disponible via l’héritage PriceableObject).</mark>
 
 <div class='table-title'>FareDemandFactor – Element</div>
 
@@ -2522,9 +2522,9 @@ titre ouvrant droit à réduction</mark></p></td>
 <span class="red">**UNIQUEMENT UTILE SI L’ALIMENTATION D’UN SYSTÈME
 BILLETTIQUE EST ENVISAGEE !**</span>
 
-<span class="mark">Note : l’ÉLÉMENT CONTRÔLABLE n’est à utiliser que
+<mark>Note : l’ÉLÉMENT CONTRÔLABLE n’est à utiliser que
 dans les contexte de l’alimentation d’un système billettique (de façon à
-lui préciser les élément effectivement à contrôler)</span>
+lui préciser les élément effectivement à contrôler)</mark>
 
 La définition d'un système tarifaire comprend toujours un niveau de base
 de droits d'accès, pour lequel les paramètres de validité contrôlés
@@ -2638,7 +2638,7 @@ A LA VENTE (voir plus loin) pour décrire un produit commercialisé que
 l'utilisateur peut acheter matérialisé sur un DOCUMENT DE VOYAGE
 (ticket, carte, mobile, etc.).
 
-<span class="mark">Note : la plupart de spécialisation de : UN PRODUIT
+<mark>Note : la plupart de spécialisation de : UN PRODUIT
 TARIFAIRE dispose d’un attribut ***ProductType***. Par convention, dans
 le cadre du profil si le produit est "*single trip*" et qu’il référence
 plusieurs ***ValidableElements***, alors le PRODUIT ne donne la
@@ -2649,7 +2649,7 @@ mécanisme pour faire un unique produit O-D, contenant de très nombreuses
 O-D, mais avec une seule tarification comme dans le cas du Yield
 Management. Pour mémoire, le ***ValidableElement*** peut lui-même être
 constitué d’une séquence de ***FareStructureElement***s, ce qui
-permettra bien de gérer toutes les situations de droits combinés.</span>
+permettra bien de gérer toutes les situations de droits combinés.</mark>
 
 ![](media/image8.png) *Produits Tarifaires (vue simplifiée) – Modèle
 conceptuel*
@@ -2668,13 +2668,13 @@ conceptuel*
 
 | **Classification** | **Name**            | **Type**                   | **Cardinality** | **Description**                                                                     |
 |--------------------|---------------------|----------------------------|-----------------|-------------------------------------------------------------------------------------|
-| ::\>               | ::\>                | *<u>PriceableObject</u>*  | ::\>            | FARE PRODUCT hérite de SERVICE ACCESS RIGHT. <br><span class="hl">Note : cet héritage fournit entre autres un attribut ***noticeAssignments*** ; dans le contexte de ce profil, c’est au niveau des ***SalesOfferPackage*** et ***FareProducts*** que l’on placera les Notices.</span>                                     | 
+| ::\>               | ::\>                | *<u>PriceableObject</u>*  | ::\>            | FARE PRODUCT hérite de SERVICE ACCESS RIGHT. <br><mark>Note : cet héritage fournit entre autres un attribut ***noticeAssignments*** ; dans le contexte de ce profil, c’est au niveau des ***SalesOfferPackage*** et ***FareProducts*** que l’on placera les Notices.</mark>                                     | 
 | « PK »             | ***id***                | *FareProductIdType*   | 0:1            | Identifiant du FARE PRODUCT.                             |
 | « FK »               | ***ChargingMomentRef***                | *ChargingMomentRef*   | 0:1            | Référence à CHARGING MOMENT associé au produit.  |
 | « enum »               | ***ChargingMomentType***                | *ChargingMomentTypeEnum*   | 0:1            | <p>Énumération des valeurs normalisées du moment de paiement.</p><p><ul><li>beforeTravel (avant le voyage)</li><li>onStartOfTravel (au départ du voyage)</li><li>beforeEndOfTravel (avant la fin du voyage)</li><li>onStartThenAdjustAtEndOfTravel (au départ avec ajustement à la fin du voyage)</li><li>onStarThenAdjustAtEndOfFareDay (au départ avec ajustement en fin de journée)</li><li>onStartThenAdjustAtEndOfChargePeriod (au départ avec ajustement en fin de période tarifaire)</li><li>atEndOfTravel (à la fin du voyage)</li><li>atEndOfFareDay (à la fin de la journée tarifaire)</li><li>atEndOfChargePeriod (à la fin de la période tarifaire)</li><li>free (gratuit)</li><li>anyTime (à n’importe quel moment)</li><li>other (autre)</li></ul></p> |
 | « FK »               | ***typesOfFareProductRef***                | *TypeOfFareProductRef*   | 0:\*            | Classifications du FARE PRODUCT.  |
 | « FK »               | ***TransportOrganisationRef***                | *(TransportOrganisationRef) OperatorRef / AuthorityRef*  | 0:1            | OPERATOR ou AUTHORITY en charge du FARE PRODUCT.  |
-| « cntd »               | ***ConditionSummary***                | *<u>ConditionSummary</u>*   | 0:1            | <p>Résumé des conditions associées au FARE PRODUCT.</p> <p><span class="hl">Note : dans le cadre du profil, seuls certains attributs des ***ConditionSummary*** sont acceptés pour le ***FareProduct*** (voir description des ***ConditionSummary***).</span></p>  |
+| « cntd »               | ***ConditionSummary***                | *<u>ConditionSummary</u>*   | 0:1            | <p>Résumé des conditions associées au FARE PRODUCT.</p> <p><mark>Note : dans le cadre du profil, seuls certains attributs des ***ConditionSummary*** sont acceptés pour le ***FareProduct*** (voir description des ***ConditionSummary***).</mark></p>  |
 | XGRP               | ***FareProductValidityGroup***                | *FareProductRef*</em>*   | 0:1            | 	Informations de validité relatives au FARE PRODUCT.  |
 
 <div class='table-title'>FareProductValidityGroup – Group</div>
@@ -3130,13 +3130,13 @@ transport. On peut, titre d’exemple, citer un titre de transport associé
 
 <div class='table-title'>ThirdPartyProduct – Element</div>
 
-| **Classification** | **Name** |                                                                | **Type**                                                   | **Cardinality**                    | **Description**                                                                                       |
-|--------------------|----------|----------------------------------------------------------------|------------------------------------------------------------|------------------------------------|-------------------------------------------------------------------------------------------------------|
-| ::\>               | ::\>     |                                                                | *<u>FareProduct</u>*                                       | ::\>                               | THIRD PARTY PRODUCT hérite de FARE PRODUCT.                                                           |
-| « PK »             | ***id*** |                                                                | *ThirdPartyProductIdType*                                  | 1:1                                | Identifiant du THIRD PARTY PRODUCT.                                                                   |
-|                    |          |                                                                | CHOICE                                                     |                                    |                                                                                                       |
-| « cntd »           | ***a***  | ***GeneralGroupOfEntities***                                   | *<u>GeneralGroupOfEntities</u>*                            | 0:1                                | GENERAL GROUP OF ENTITIES associé au THIRD PARTY PRODUCT.                                             |
-| « cntd »           | ***a***  | ***<span class="mark-blue">GeneralGroupOfEntitiesRef</span>*** | *<span class="mark-blue">GeneralGroupOfEntitiesRef</span>* | <span class="mark-blue">0:1</span> | <span class="mark-blue">Référence à GENERAL GROUP OF ENTITIES associé au Third PARTY product.</span> |
+| **Classification** | **Name** |                                                           | **Type**                                              | **Cardinality**               | **Description**                                                                                 |
+|--------------------|----------|-----------------------------------------------------------|-------------------------------------------------------|-------------------------------|-------------------------------------------------------------------------------------------------|
+| ::\>               | ::\>     |                                                           | *<u>FareProduct</u>*                                  | ::\>                          | THIRD PARTY PRODUCT hérite de FARE PRODUCT.                                                     |
+| « PK »             | ***id*** |                                                           | *ThirdPartyProductIdType*                             | 1:1                           | Identifiant du THIRD PARTY PRODUCT.                                                             |
+|                    |          |                                                           | CHOICE                                                |                               |                                                                                                 |
+| « cntd »           | ***a***  | ***GeneralGroupOfEntities***                              | *<u>GeneralGroupOfEntities</u>*                       | 0:1                           | GENERAL GROUP OF ENTITIES associé au THIRD PARTY PRODUCT.                                       |
+| « cntd »           | ***a***  | ***<mark class="blue">GeneralGroupOfEntitiesRef</mark>*** | *<mark class="blue">GeneralGroupOfEntitiesRef</mark>* | <mark class="blue">0:1</mark> | <mark class="blue">Référence à GENERAL GROUP OF ENTITIES associé au Third PARTY product.</mark> |
 
 ### Résumé Des Conditions Tarifaires 
 
@@ -3163,15 +3163,15 @@ TARIFAIRES.
 
 ![](media/image10.png) *Résume des conditions – Modèle physique*
 
-<span class="mark">Note : les attributs du ***ConditionSummary*** sont
-spécialisés par le profil NeTEx Tarif France</span>. Ainsi certains sont
+<mark>Note : les attributs du ***ConditionSummary*** sont
+spécialisés par le profil NeTEx Tarif France</mark>. Ainsi certains sont
 uniquement destinés à être utilisés par les PRODUITs TARIFAIREs (Fare
 Product) et d’autres sont réservés aux OFFREs À LA VENTE
 (SalesPackageOffer). Cette restriction et ce systématisme ont pour
 vocation de simplifier l’usage d’un profil (placer une information donnée
 à un endroit unique quand cela est possible). Une colonne précisant
-**<span class="mark">PT</span>** (PRODUITs TARIFAIRE) ou
-**<span class="mark">OalV</span>** (OFFRE À LA VENTE) a été ajoutée pour
+**<mark>PT</mark>** (PRODUITs TARIFAIRE) ou
+**<mark>OalV</mark>** (OFFRE À LA VENTE) a été ajoutée pour
 préciser cette affectation (s’il n’y a pas de précision, l’attribut
 reste utilisable dans les deux cas)*.*
 
@@ -3305,20 +3305,20 @@ SUMMARY.</td>
 
 | **Classification** | **Name**              | **Type**      | **Cardinality** | **Description**                                                                                       |                                    |
 |--------------------|-----------------------|---------------|-----------------|-------------------------------------------------------------------------------------------------------|------------------------------------|
-|                    | ***ProvidesCard***    | *xsd:boolean* | 0:1             | Indique si une carte est fournie avec le produit.                                                     | **<span class="mark">OalV</span>** |
-|                    | ***GoesOnCard***      | *xsd:boolean* | 0:1             | Indique si le produit va sur une carte.                                                               | **<span class="mark">OalV</span>** |
-|                    | ***IsPersonal***      | *xsd:boolean* | 0:1             | Indique si que le produit est vendu de manière anonyme ou à une personne identifiée.                  | **<span class="mark">OalV</span>** |
-|                    | ***RequiresPhoto***   | *xsd:boolean* | 0:1             | Indique si l'utilisation du produit nécessite la fourniture d'une photo.                              | **<span class="mark">OalV</span>** |
-|                    | ***MustCarry***       | *xsd:boolean* | 0:1             | Indique si la carte, le support, doit être transporté lors du déplacement afin d'utiliser le produit. | **<span class="mark">OalV</span>** |
-|                    | ***RequiresAccount*** | *xsd:boolean* | 0:1             | Indique si le produit nécessite que l'utilisateur crée un compte pour la facturation.                 | **<span class="mark">OalV</span>** |
+|                    | ***ProvidesCard***    | *xsd:boolean* | 0:1             | Indique si une carte est fournie avec le produit.                                                     | **<mark>OalV</mark>**              |
+|                    | ***GoesOnCard***      | *xsd:boolean* | 0:1             | Indique si le produit va sur une carte.                                                               | **<mark>OalV</mark>**              |
+|                    | ***IsPersonal***      | *xsd:boolean* | 0:1             | Indique si que le produit est vendu de manière anonyme ou à une personne identifiée.                  | **<mark>OalV</mark>**              |
+|                    | ***RequiresPhoto***   | *xsd:boolean* | 0:1             | Indique si l'utilisation du produit nécessite la fourniture d'une photo.                              | **<mark>OalV</mark>**              |
+|                    | ***MustCarry***       | *xsd:boolean* | 0:1             | Indique si la carte, le support, doit être transporté lors du déplacement afin d'utiliser le produit. | **<mark>OalV</mark>**              |
+|                    | ***RequiresAccount*** | *xsd:boolean* | 0:1             | Indique si le produit nécessite que l'utilisateur crée un compte pour la facturation.                 | **<mark>OalV</mark>**              |
 
 <div class='table-title'>ConditionSummaryEntitlementGroup – Group</div>
 
 | **Classification** | **Name**                  | **Type**      | **Cardinality** | **Description**                                                        |                                  |
 |--------------------|---------------------------|---------------|-----------------|------------------------------------------------------------------------|----------------------------------|
-|                    | ***IsSupplement***        | *xsd:boolean* | 0:1             | Indique si le produit est un complément à un autre produit             | **<span class="mark">PT</span>** |
-|                    | ***RequiresEntitlement*** | *xsd:boolean* | 0:1             | Indique si le produit nécessite un droit ouvert par d'autres produits. | **<span class="mark">PT</span>** |
-|                    | ***GivesEntitlement***    | *xsd:boolean* | 0:1             | Indique si le produit ouvre des droits à d'autres produits.            | **<span class="mark">PT</span>** |
+|                    | ***IsSupplement***        | *xsd:boolean* | 0:1             | Indique si le produit est un complément à un autre produit             | **<mark>PT</mark>**              |
+|                    | ***RequiresEntitlement*** | *xsd:boolean* | 0:1             | Indique si le produit nécessite un droit ouvert par d'autres produits. | **<mark>PT</mark>**              |
+|                    | ***GivesEntitlement***    | *xsd:boolean* | 0:1             | Indique si le produit ouvre des droits à d'autres produits.            | **<mark>PT</mark>**              |
 
 <div class='table-title'>ConditionSummaryTravelGroup – Group</div>
 
@@ -3415,32 +3415,32 @@ puis à reprendre son trajet.</td>
 
 | **Classification** | **Name**                       | **Type**      | **Cardinality** | **Description**                                                                                               |                                    |
 |--------------------|--------------------------------|---------------|-----------------|---------------------------------------------------------------------------------------------------------------|------------------------------------|
-|                    | ***CanChangeClass***           | *xsd:boolean* | 0:1             | Indique si l'utilisateur peut changer de classe                                                               | **<span class="mark">PT</span>**   |
-|                    | ***IsRefundable***             | *xsd:boolean* | 0:1             | Indique si le billet est remboursable                                                                         | **<span class="mark">OalV</span>** |
-|                    | ***IsExchangable***            | *xsd:boolean* | 0:1             | Indique si le billet est échangeable                                                                          | **<span class="mark">OalV</span>** |
-|                    | ***HasExchangeFee***           | *xsd:boolean* | 0:1             | Indique s'il y a des frais pour les échanges.                                                                 | **<span class="mark">OalV</span>** |
-|                    | ***HasDiscountedFares***       | *xsd:boolean* | 0:1             | Indique si les tarifs réduits sont autorisés.                                                                 | **<span class="mark">PT</span>**   |
-|                    | ***AllowAdditionalDiscounts*** | *xsd:boolean* | 0:1             | Indique si plusieurs remises peuvent être appliquées, par ex. Enfant + Accompagnateur.                        | **<span class="mark">PT</span>**   |
-|                    | ***AllowCompanionDiscount***   | *xsd:boolean* | 0:1             | Indique s'il y a une remise pour les accompagnateur.                                                          | **<span class="mark">PT</span>**   |
-|                    | ***HasMinimumPrice***          | *xsd:boolean* | 0:1             | Indique s'il y a un prix minimum lors de la combinaison de remises.                                           | **<span class="mark">PT</span>**   |
-|                    | ***RequiresPositiveBalance***  | *xsd:boolean* | 0:1             | Indique si le produit nécessite un solde positif (généralement sur une carte de transport) pour être utilisé. | **<span class="mark">OalV</span>** |
+|                    | ***CanChangeClass***           | *xsd:boolean* | 0:1             | Indique si l'utilisateur peut changer de classe                                                               | **<mark>PT</mark>**                |
+|                    | ***IsRefundable***             | *xsd:boolean* | 0:1             | Indique si le billet est remboursable                                                                         | **<mark>OalV</mark>**              |
+|                    | ***IsExchangable***            | *xsd:boolean* | 0:1             | Indique si le billet est échangeable                                                                          | **<mark>OalV</mark>**              |
+|                    | ***HasExchangeFee***           | *xsd:boolean* | 0:1             | Indique s'il y a des frais pour les échanges.                                                                 | **<mark>OalV</mark>**              |
+|                    | ***HasDiscountedFares***       | *xsd:boolean* | 0:1             | Indique si les tarifs réduits sont autorisés.                                                                 | **<mark>PT</mark>**                |
+|                    | ***AllowAdditionalDiscounts*** | *xsd:boolean* | 0:1             | Indique si plusieurs remises peuvent être appliquées, par ex. Enfant + Accompagnateur.                        | **<mark>PT</mark>**                |
+|                    | ***AllowCompanionDiscount***   | *xsd:boolean* | 0:1             | Indique s'il y a une remise pour les accompagnateur.                                                          | **<mark>PT</mark>**                |
+|                    | ***HasMinimumPrice***          | *xsd:boolean* | 0:1             | Indique s'il y a un prix minimum lors de la combinaison de remises.                                           | **<mark>PT</mark>**                |
+|                    | ***RequiresPositiveBalance***  | *xsd:boolean* | 0:1             | Indique si le produit nécessite un solde positif (généralement sur une carte de transport) pour être utilisé. | **<mark>OalV</mark>**              |
 
 <div class='table-title'>ConditionSummaryReservationGroup – Group</div>
 
 | **Classification** | **Name**                      | **Type**      | **Cardinality** | **Description**                                                                                                          |                                    |
 |--------------------|-------------------------------|---------------|-----------------|--------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-|                    | ***PenaltyWIthoutTicket***    | *xsd:boolean* | 0:1             | Indique s'il y a une pénalité pour voyager sans billet, c'est-à-dire que les billets ne peuvent pas être achetés à bord. | **<span class="mark">OalV</span>** |
-|                    | ***AvailableOnSubscription*** | *xsd:boolean* | 0:1             | Indique si le produit est disponible sur abonnement.                                                                     | **<span class="mark">OalV</span>** |
+|                    | ***PenaltyWIthoutTicket***    | *xsd:boolean* | 0:1             | Indique s'il y a une pénalité pour voyager sans billet, c'est-à-dire que les billets ne peuvent pas être achetés à bord. | **<mark>OalV</mark>**              |
+|                    | ***AvailableOnSubscription*** | *xsd:boolean* | 0:1             | Indique si le produit est disponible sur abonnement.                                                                     | **<mark>OalV</mark>**              |
 
 <div class='table-title'>ConditionSummaryReservationGroup – Group</div>
 
 | **Classification** | **Name**                    | **Type**      | **Cardinality** | **Description**                                                                                                           |                                    |
 |--------------------|-----------------------------|---------------|-----------------|---------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-|                    | ***HasPurchaseConditions*** | *xsd:boolean* | 0:1             | Indique si les conditions d'achat s'appliquent à la vente du produit, par ex. quand doit être acheté ou qui peut acheter. | **<span class="mark">OalV</span>** |
-|                    | ***HasDynamicPricing***     | *xsd:boolean* | 0:1             | Indique si le produit a une tarification dynamique.                                                                       | **<span class="mark">PT</span>**   |
-|                    | ***RequiresReservation***   | *xsd:boolean* | 0:1             | Indique si le produit nécessite une réservation.                                                                          | **<span class="mark">OalV</span>** |
-|                    | ***HasReservationFee***     | *xsd:boolean* | 0:1             | Indique si la réservation est payante.                                                                                    | **<span class="mark">OalV</span>** |
-|                    | ***HasQuota***              | *xsd:boolean* | 0:1             | Indique qu'il y a un quota limité pour l'offre ou qu'elle est vendue en nombre illimité.                                  | **<span class="mark">OalV</span>** |
+|                    | ***HasPurchaseConditions*** | *xsd:boolean* | 0:1             | Indique si les conditions d'achat s'appliquent à la vente du produit, par ex. quand doit être acheté ou qui peut acheter. | **<mark>OalV</mark>**              |
+|                    | ***HasDynamicPricing***     | *xsd:boolean* | 0:1             | Indique si le produit a une tarification dynamique.                                                                       | **<mark>PT</mark>**                |
+|                    | ***RequiresReservation***   | *xsd:boolean* | 0:1             | Indique si le produit nécessite une réservation.                                                                          | **<mark>OalV</mark>**              |
+|                    | ***HasReservationFee***     | *xsd:boolean* | 0:1             | Indique si la réservation est payante.                                                                                    | **<mark>OalV</mark>**              |
+|                    | ***HasQuota***              | *xsd:boolean* | 0:1             | Indique qu'il y a un quota limité pour l'offre ou qu'elle est vendue en nombre illimité.                                  | **<mark>OalV</mark>**              |
 
 ### Exemple
 
@@ -4441,24 +4441,24 @@ caractéristique comparée, par exemple :
 - « LE » est égal ou inférieur au paramètre, par exemple : le voyage
   doit se terminer avant « 23h00 ».
 
-<span class="mark">Note : à chaque fois que cela est possible, on
+<mark>Note : à chaque fois que cela est possible, on
 préfèrera faire porter les ***ValidityParameter***s par le
 **FareProduct**… le passage par le ***SalesOffPackage***, ou le
 ***ValidableElement*** (voir le ***FareStructureElement***) ne se fera
 que si les droits sont véritablement complètement spécifiques à ces
-concepts.</span>
+concepts.</mark>
 
-<span class="mark">A titre d’exemple l’association des
+<mark>A titre d’exemple l’association des
 ***ValidityParameter***s au ***SalesOffPackage*** sera justifiée si le
 fait de porter son titre sur une « carte grand voyageur » donnait accès
 à une « salon grand voyageur » ce qui ne serait pas le cas pour le même
-titre sur billet papier ou billet électronique.</span>
+titre sur billet papier ou billet électronique.</mark>
 
-<span class="mark">De plus, seuls les ***ValidityParameter***s
+<mark>De plus, seuls les ***ValidityParameter***s
 génériques sur un ***FareProduct*** seront affectés « en dur », et toutes
 les variantes avec impact sur le prix (réduction famille nombreuse,
 tarifs enfants, etc. pour ce même ***FareProduct***) seront affectées via
-une ***FareTable***.</span>
+une ***FareTable***.</mark>
 
 La figure ci-dessous propose une vue d’ensemble des affectations de
 droits : on y voit clairement que des droits peuvent apparaitre à tous
@@ -4467,10 +4467,10 @@ façons de décrire les tarifs.
 
 L’AFFECTATION DES PARAMÈTRES DES DROITS D'ACCÈS (ACCESS RIGHT PARAMETER
 ASSIGNMENT) est l’élément central de l’affectation des droits.
-<span class="mark">Toutefois, dans le contexte du profil, il est considéré
+<mark>Toutefois, dans le contexte du profil, il est considéré
 comme abstrait et on ne l’instanciera pas en tant qu’élément XML, mais
 uniquement via sa spécialisation en AFFECTATION DES PARAMÈTRES
-GÉNÉRIQUES (GENERIC PARAMETER ASSIGNMENT).</span>
+GÉNÉRIQUES (GENERIC PARAMETER ASSIGNMENT).</mark>
 
 L’AFFECTATION DE PARAMÈTRES GÉNÉRIQUES (GENERIC PARAMETER ASSIGNMENT)
 spécifie donc les droits d'accès génériques pour une classe de produits
@@ -5206,7 +5206,7 @@ s'ajoute l'&#xE9;ventuelle diff&#xE9;rence de prix entre l'ancien et le nouveau 
 
 ## Les Grilles Tarifaires (FareTable)
 
-<span class="mark">Dans tous les tableaux précédents, les attributs
+<mark>Dans tous les tableaux précédents, les attributs
 fournissant une information de prix n'ont pas été retenus dans le cadre du
 Profil France : cela tient au fait que l’option retenue par le profil
 est de systématiser la présentation des prix au travers d’une GRILLE
@@ -5214,23 +5214,23 @@ TARIFAIRE (FARE TABLE). L’objectif est ici de systématiser la production
 et l’interprétation des données d’ordre tarifaire, mais aussi d’éviter
 une trop grande disparité des choix et options de modélisation qui ne
 manquerait pas de se présenter (surtout dans le domaine tarifaire) s’il
-elles n’étaient pas un peu contraintes.</span>
+elles n’étaient pas un peu contraintes.</mark>
 
-<span class="mark">La présentation des prix sous forme de grille des
+<mark>La présentation des prix sous forme de grille des
 tarifs reste un grand classique dans le domaine des transports, et ce
 choix permettra aussi la simplification de la présentation de l’offre
 aux voyageur (ce qui est cohérent avec l’objectif d’information voyageur
-du profil).</span>
+du profil).</mark>
 
-<span class="mark">Il reste toutefois quelques cas où des prix pourront
+<mark>Il reste toutefois quelques cas où des prix pourront
 être fournis en dehors des GRILLEs TARIFAIREs : par exemple si un
 produit offre une réduction fixe, par exemple de 5€, cela pourra être
 indiqué explicitement dans la description du produit tarifaire de façon
 à pouvoir en donner une description complète et pertinente au
-voyageur.</span>
+voyageur.</mark>
 
-<span class="mark">Note : dans le cadre du profil, on fait le choix de
-ne pas prévoir la gestion de réductions cumulatives.</span>
+<mark>Note : dans le cadre du profil, on fait le choix de
+ne pas prévoir la gestion de réductions cumulatives.</mark>
 
 Une GRILLE TARIFAIRE permet la représentation de groupes de prix pour
 des combinaisons d'éléments tarifaires. Il définit une matrice
@@ -5251,10 +5251,10 @@ un prix correspondant (par exemple : Titre pour zones A et B + billet à
 l’unité + jeune voyageur (18-25 ans) =\> Prix). On conserve donc une
 construction très modulaire.
 
-<span class="mark">La GRILLE TARIFAIRE fera des références vers tous les
+<mark>La GRILLE TARIFAIRE fera des références vers tous les
 éléments qui la constituent à l’exception des prix eux-mêmes qui, n’étant
 pas définis par ailleurs, devront être complètement définis au sein de
-la GRILLE TARIFAIRE.</span>
+la GRILLE TARIFAIRE.</mark>
 
 ![](media/image24.png) *Grilles Tarifaires – Modèle conceptuel*
 
@@ -5711,22 +5711,22 @@ TABLE)</mark></p></td>
 
 <div class='table-title'>FarePrice – Element (abstrait)</div>
 
-| **Classification** | **Name**                                   | **Type**                                     | **Cardinality**                    | **Description**                                                                            |
-|--------------------|--------------------------------------------|----------------------------------------------|------------------------------------|--------------------------------------------------------------------------------------------|
-| ::\>               | ::\>                                       | *<u>VersionedChild</u>*                      | ::\>                               | FARE PRICE hérite de VERSIONED CHILD                                                       |
-| « PK »             | ***id***                                   | *FarePriceIdType*                            | 1:1                                | Identifiant du FARE PRICE.                                                                 |
-|                    | ***Name***                                 | *MultilingualString*                         | 0:1                                | Nom du PRICE.                                                                              |
-|                    | ***Description***                          | *MultilingualString*                         | 0:1                                | Description du PRICE.                                                                      |
-|                    | ***PrivateCode***                          | *PrivateCode*                                | 0:1                                | Identifiant externe du PRICE.                                                              |
-|                    | ***StartDate***                            | *xsd:date*                                   | 0:1                                | Date de départ pour la validité du PRICE.                                                  |
-|                    | ***EndDate***                              | *xsd:date*                                   | 0:1                                | Date de fin pour la validité du PRICE.                                                     |
-|                    | ***Amount***                               | *AmountType*                                 | 0:1                                | Prix dans l’unité monétaire convenue.                                                      |
-|                    | ***Currency***                             | *CurrencyType*                               | 0:1                                | Code de devise ISO 4217 (Ceci dans une optimisation permettant d'omettre les PRICE UNITs). |
-| « FK »             | ***PriceUnitRef***                         | *PriceUnitRef*                               | 0:1                                | Référence à un PRICE UNIT ; peut-être remplacé par ***Currency***.                          |
-|                    | ***<span class="mark-blue">Units</span>*** | *<span class="mark-blue">xsd:decimal</span>* | <span class="mark-blue">0:1</span> | <span class="mark-blue">Nombe d'unités désignée.</span>                                    |
-| « FK »             | ***PricingServiceRef***                    | *PricingServiceRef*                          | 0:1                                | Référence à un PRICE SERVICE qui peut fournir le prix (pour la tarification dynamique).    |
-| XGRP               | ***FarePriceCalculationGroup***            | ***<u>xmlGroup</u>***                        | 0:1                                | Éléments régissant le calcul des prix.                                                     |
-|                    | ***Ranking***                              | *xsd:integer*                                | 0:1                                | Classement relatif du prix par rapport aux autres prix.                                    |
+| **Classification** | **Name**                              | **Type**                                | **Cardinality**               | **Description**                                                                            |
+|--------------------|---------------------------------------|-----------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------|
+| ::\>               | ::\>                                  | *<u>VersionedChild</u>*                 | ::\>                          | FARE PRICE hérite de VERSIONED CHILD                                                       |
+| « PK »             | ***id***                              | *FarePriceIdType*                       | 1:1                           | Identifiant du FARE PRICE.                                                                 |
+|                    | ***Name***                            | *MultilingualString*                    | 0:1                           | Nom du PRICE.                                                                              |
+|                    | ***Description***                     | *MultilingualString*                    | 0:1                           | Description du PRICE.                                                                      |
+|                    | ***PrivateCode***                     | *PrivateCode*                           | 0:1                           | Identifiant externe du PRICE.                                                              |
+|                    | ***StartDate***                       | *xsd:date*                              | 0:1                           | Date de départ pour la validité du PRICE.                                                  |
+|                    | ***EndDate***                         | *xsd:date*                              | 0:1                           | Date de fin pour la validité du PRICE.                                                     |
+|                    | ***Amount***                          | *AmountType*                            | 0:1                           | Prix dans l’unité monétaire convenue.                                                      |
+|                    | ***Currency***                        | *CurrencyType*                          | 0:1                           | Code de devise ISO 4217 (Ceci dans une optimisation permettant d'omettre les PRICE UNITs). |
+| « FK »             | ***PriceUnitRef***                    | *PriceUnitRef*                          | 0:1                           | Référence à un PRICE UNIT ; peut-être remplacé par ***Currency***.                         |
+|                    | ***<mark class="blue">Units</mark>*** | *<mark class="blue">xsd:decimal</mark>* | <mark class="blue">0:1</mark> | <mark class="blue">Nombe d'unités désignée.</mark>                                         |
+| « FK »             | ***PricingServiceRef***               | *PricingServiceRef*                     | 0:1                           | Référence à un PRICE SERVICE qui peut fournir le prix (pour la tarification dynamique).    |
+| XGRP               | ***FarePriceCalculationGroup***       | ***<u>xmlGroup</u>***                   | 0:1                           | Éléments régissant le calcul des prix.                                                     |
+|                    | ***Ranking***                         | *xsd:integer*                           | 0:1                           | Classement relatif du prix par rapport aux autres prix.                                    |
 
 <div class='table-title'>FarePriceCalculationGroup – Group</div>
 
@@ -5890,14 +5890,14 @@ ici de 30%.
 ![](media/image26.png) *Exemple de tarif particulier pouvant justifier
 l’usage d’une note pour le simplifier*
 
-<span class="mark">Autre élément important dans le cadre de ce profil :
+<mark>Autre élément important dans le cadre de ce profil :
 les Notices seront exclusivement rattachées aux grilles tarifaires
 (***FareTable***), qui permettra en fait de l’associer à une offre à la
 vente (***SalesOfferPackage***), ou éventuellement à un produit
 tarifaire (***PreassignedFareProduct***). Théoriquement une note peut
 être attachée à n’importe quel objet mais attacher les note sans règle à
 de nombreux endroits rendrait l’exploitation de la donnée très
-délicate.</span>
+délicate.</mark>
 
 Il sera aussi souvent utile de pouvoir proposer des traductions des
 notes dans différentes langues : on procédera naturellement à ces
@@ -10337,8 +10337,7 @@ service interfaces - Situation Exchange
 </div>
 
 <style>
-  .mark      { background-color: yellow; }
-  .mark-blue { background-color: cyan;   }
+  mark.blue { background-color: cyan; }
 
   .red { color: red; }
 


### PR DESCRIPTION
Cette PR ne modifie pas le contenu du profil France. Elle vise à uniformiser la source des différents sous-profils une future analyse.

Tous les éléments surlignés devraient utiliser le même markup HTML :

```html
Les textes surlignés en <mark>jaune</mark> sont ceux présentant une
particularité (spécialisation) par rapport à NeTEx (...)
```

Les sous-profils Tarifs et Parkings ne respectaient pas cette convention et uilisaient un `<span>` avec une classe CSS dédiée. Ca date de la transposition des documents Word source (my bad).

Pour les singularités des sous-profils Tarifs et Parkings, les textes surlignés en d'autres couleurs utilisent toujours une classe CSS dédiée mais sur l'élément standard `mark` :

```html
<!-- sous-profil Tarifs -->
Les textes surlignés en <mark class="blue">bleu</mark>
correspondent à des éléments de NeTEx non retenus dans le cadre de ce
profil (présentés à titre informatif donc)

<!-- sous-profil Parkings -->
<mark class="gray">text surligné en gris clair</mark>
```

A noter que pour le sous-profil Parkings, il n'y a pas de légende expliquant ce qu'un texte surligné en gris signifie.